### PR TITLE
Adjust media server path mapping

### DIFF
--- a/lib/core/utils/media_path_mapper.dart
+++ b/lib/core/utils/media_path_mapper.dart
@@ -2,6 +2,7 @@ import 'package:path/path.dart' as p;
 
 class MediaPathMapper {
   static const String _assetsPrefix = 'assets/';
+  static const String _assetsImagesPrefix = 'assets/images/';
 
   const MediaPathMapper._();
 
@@ -17,10 +18,16 @@ class MediaPathMapper {
   }
 
   /// Returns the path that should be used under the `/media` endpoint.
-  /// Example: `assets/images/amarillo/Amigo.png` → `images/amarillo/Amigo.png`.
+  /// Example: `assets/images/amarillo/Amigo.png` → `amarillo/Amigo.png`.
   static String toServerPath(String relativePath) {
     final normalized = normalize(relativePath);
-    return normalized.substring(_assetsPrefix.length);
+    if (normalized.startsWith(_assetsImagesPrefix)) {
+      return normalized.substring(_assetsImagesPrefix.length);
+    }
+    if (normalized.startsWith(_assetsPrefix)) {
+      return normalized.substring(_assetsPrefix.length);
+    }
+    return normalized;
   }
 
   /// Utility to resolve the local absolute path within [rootDirectoryPath]


### PR DESCRIPTION
## Summary
- update the media path mapper to remove the `assets/images/` prefix when generating server paths so remote URLs no longer include the extra images segment

## Testing
- flutter test *(fails: flutter: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ff25cd6fc832fa638e720b25e2c12)