### PR TITLE
feat: allow adding custom pictograms

### DIFF
--- a/lib/core/bindings/home_binding.dart
+++ b/lib/core/bindings/home_binding.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import 'package:xpressatec/data/datasources/local/local_storage.dart';
 import 'package:xpressatec/data/repositories/teacch_repository_impl.dart';
 import 'package:xpressatec/domain/repositories/teacch_repository.dart';
 import 'package:xpressatec/presentation/features/chat/controllers/chat_controller.dart';
@@ -16,7 +17,9 @@ class HomeBinding extends Bindings {
   @override
   void dependencies() {
     // Repository
-    Get.lazyPut<TeacchRepository>(() => TeacchRepositoryImpl());
+    Get.lazyPut<TeacchRepository>(
+      () => TeacchRepositoryImpl(localStorage: Get.find<LocalStorage>()),
+    );
 
     // Controllers
     Get.lazyPut(() => NavigationController());

--- a/lib/data/datasources/local/local_storage.dart
+++ b/lib/data/datasources/local/local_storage.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../models/custom_pictogram.dart';
+
 class LocalStorage {
   late SharedPreferences _prefs;
 
@@ -8,6 +10,8 @@ class LocalStorage {
   static final LocalStorage _instance = LocalStorage._internal();
   factory LocalStorage() => _instance;
   LocalStorage._internal();
+
+  static const String _customPictogramsKey = 'custom_pictograms';
 
   /// Initialize SharedPreferences
   Future<void> init() async {
@@ -210,6 +214,33 @@ class LocalStorage {
   /// Check if key exists
   bool containsKey(String key) {
     return _prefs.containsKey(key);
+  }
+
+  // ==================== CUSTOM PICTOGRAMS ====================
+
+  Future<void> saveCustomPictograms(List<CustomPictogram> pictograms) async {
+    try {
+      final encoded = jsonEncode(pictograms.map((p) => p.toMap()).toList());
+      await _prefs.setString(_customPictogramsKey, encoded);
+    } catch (e) {
+      print('✗ Error saving custom pictograms: $e');
+    }
+  }
+
+  Future<List<CustomPictogram>> getCustomPictograms() async {
+    try {
+      final encoded = _prefs.getString(_customPictogramsKey);
+      if (encoded == null || encoded.isEmpty) {
+        return [];
+      }
+      final List<dynamic> decoded = jsonDecode(encoded);
+      return decoded
+          .map((e) => CustomPictogram.fromMap(Map<String, dynamic>.from(e)))
+          .toList();
+    } catch (e) {
+      print('✗ Error loading custom pictograms: $e');
+      return [];
+    }
   }
 
 

--- a/lib/data/models/custom_pictogram.dart
+++ b/lib/data/models/custom_pictogram.dart
@@ -1,0 +1,52 @@
+class CustomPictogram {
+  const CustomPictogram({
+    required this.id,
+    required this.name,
+    required this.relativePath,
+    required this.parentPath,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  final String id;
+  final String name;
+  final String relativePath;
+  final String parentPath;
+  final DateTime createdAt;
+
+  CustomPictogram copyWith({
+    String? id,
+    String? name,
+    String? relativePath,
+    String? parentPath,
+    DateTime? createdAt,
+  }) {
+    return CustomPictogram(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      relativePath: relativePath ?? this.relativePath,
+      parentPath: parentPath ?? this.parentPath,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'relativePath': relativePath,
+      'parentPath': parentPath,
+      'createdAt': createdAt.toIso8601String(),
+    };
+  }
+
+  factory CustomPictogram.fromMap(Map<String, dynamic> map) {
+    final createdAt = map['createdAt'] as String?;
+    return CustomPictogram(
+      id: map['id'] as String,
+      name: map['name'] as String,
+      relativePath: map['relativePath'] as String,
+      parentPath: map['parentPath'] as String,
+      createdAt: createdAt != null ? DateTime.tryParse(createdAt) : null,
+    );
+  }
+}

--- a/lib/data/repositories/teacch_repository_impl.dart
+++ b/lib/data/repositories/teacch_repository_impl.dart
@@ -1,10 +1,16 @@
 import 'package:flutter/services.dart';
 import 'dart:convert';
 
+import '../../core/utils/media_path_mapper.dart';
+import '../datasources/local/local_storage.dart';
+import '../models/custom_pictogram.dart';
 import '../../domain/repositories/teacch_repository.dart';
 
 class TeacchRepositoryImpl implements TeacchRepository {
-  // ... tus otras implementaciones
+  TeacchRepositoryImpl({LocalStorage? localStorage})
+      : _localStorage = localStorage ?? LocalStorage();
+
+  final LocalStorage _localStorage;
 
   @override
   Future<Map<String, List<String>>> getAssetPaths(String rootPath) async {
@@ -38,18 +44,55 @@ class TeacchRepositoryImpl implements TeacchRepository {
         // Si hay subdirectorios, los procesamos.
         for (final dir in subdirectories) {
           final dirPath = '$rootPath/$dir';
-          result[dir] = allPaths.where((p) => p.startsWith(dirPath) && !p.endsWith('portada.png')).toList();
+          result[dir] = allPaths
+              .where((p) => p.startsWith(dirPath) && !p.endsWith('portada.png'))
+              .toList();
         }
       } else {
         // Si no hay subdirectorios, devolvemos las imágenes directas.
         result['main'] = directImages;
       }
-        print("Assets encontrados para '$rootPath': $result");
+
+      await _mergeCustomPictograms(result, rootPath);
+      print("Assets encontrados para '$rootPath': $result");
       return result;
 
     } catch (e) {
       print("Error loading asset paths: $e");
       return {};
+    }
+  }
+
+  Future<void> _mergeCustomPictograms(
+    Map<String, List<String>> result,
+    String rootPath,
+  ) async {
+    final List<CustomPictogram> customPictograms =
+        await _localStorage.getCustomPictograms();
+    if (customPictograms.isEmpty) {
+      return;
+    }
+
+    for (final pictogram in customPictograms) {
+      final normalizedPath = MediaPathMapper.normalize(pictogram.relativePath);
+      if (!normalizedPath.startsWith(rootPath)) {
+        continue;
+      }
+
+      final normalizedParent = MediaPathMapper.normalize(pictogram.parentPath);
+      String parentRelative = '';
+      if (normalizedParent.length > rootPath.length) {
+        parentRelative = normalizedParent.substring(rootPath.length + 1);
+      }
+
+      final String targetKey = parentRelative.isEmpty
+          ? 'main'
+          : parentRelative.split('/').first;
+
+      final list = result.putIfAbsent(targetKey, () => <String>[]);
+      if (!list.contains(normalizedPath)) {
+        list.add(normalizedPath);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a local CustomPictogram model plus SharedPreferences helpers to persist custom pictograms per device
- extend the customization controller and screen so users can add new pictograms and immediately see them in the tree
- merge stored custom pictograms into TEACCH repository lookups so the board can use the new assets

## Testing
- Not run (flutter command unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691025cddd20832fb920661fefa33f96)