### PR TITLE
Implement role-based navigation and chat guard

### DIFF
--- a/lib/presentation/features/auth/controllers/auth_controller.dart
+++ b/lib/presentation/features/auth/controllers/auth_controller.dart
@@ -7,25 +7,11 @@ import '../../../../domain/usecases/auth/register_usecase.dart';
 import '../../../../core/config/routes.dart';
 
 class AuthController extends GetxController {
-
-
-
-  @override
-  void onInit() {
-    super.onInit();
-    _loadCurrentUser(); // Load user on startup
-  }
-
-
-
-
   // Observable state
   final Rx<User?> currentUser = Rx<User?>(null);
   final RxBool isLoading = false.obs;
   final RxString errorMessage = ''.obs;
-  final RxString selectedRole = 'Paciente'.obs;  // ADD THIS LINE
-
-
+  final RxString selectedRole = 'Paciente'.obs;
 
   final LoginUseCase loginUseCase;
   final RegisterUseCase registerUseCase;
@@ -39,12 +25,22 @@ class AuthController extends GetxController {
     required this.getCurrentUserUseCase,
   });
 
-
+  @override
+  void onInit() {
+    super.onInit();
+    _loadCurrentUser(); // Load user on startup
+  }
 
   // Computed properties for UI
   RxString get userName => (currentUser.value?.nombre ?? 'Usuario').obs;
   RxString get userEmail => (currentUser.value?.email ?? '').obs;
   RxString get userRole => (currentUser.value?.rol ?? '').obs;
+
+  // Role helpers
+  bool get isPaciente => currentUser.value?.isPaciente ?? false;
+  bool get isTutor => currentUser.value?.isTutor ?? false;
+  bool get isTerapeuta => currentUser.value?.isTerapeuta ?? false;
+  bool get canAccessChat => isTutor || isTerapeuta;
 
   // Login
   Future<void> login({

--- a/lib/presentation/features/home/controllers/navigation_controller.dart
+++ b/lib/presentation/features/home/controllers/navigation_controller.dart
@@ -1,9 +1,57 @@
-
 import 'package:get/get.dart';
+import 'package:xpressatec/domain/entities/user.dart';
+import 'package:xpressatec/presentation/features/auth/controllers/auth_controller.dart';
+
+enum NavigationSection { teacch, chat, customization, statistics }
+
 class NavigationController extends GetxController {
-  final currentIndex = 0.obs;
+  final RxInt currentIndex = 0.obs;
+  final RxList<NavigationSection> sections = <NavigationSection>[
+    NavigationSection.teacch,
+    NavigationSection.customization,
+    NavigationSection.statistics,
+  ].obs;
+
+  late final AuthController _authController;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _authController = Get.find<AuthController>();
+    _configureSections(_authController.currentUser.value);
+    ever<User?>(_authController.currentUser, _configureSections);
+  }
 
   void changePage(int index) {
-    currentIndex.value = index;
+    if (index < sections.length) {
+      currentIndex.value = index;
+    }
+  }
+
+  NavigationSection get currentSection {
+    if (sections.isEmpty) {
+      return NavigationSection.teacch;
+    }
+    final safeIndex = currentIndex.value.clamp(0, sections.length - 1);
+    return sections[(safeIndex as num).toInt()];
+  }
+
+  void _configureSections(User? user) {
+    final isTutor = user?.isTutor ?? false;
+    final isTerapeuta = user?.isTerapeuta ?? false;
+
+    final updatedSections = <NavigationSection>[
+      NavigationSection.teacch,
+      if (isTutor || isTerapeuta) NavigationSection.chat,
+      NavigationSection.customization,
+      NavigationSection.statistics,
+    ];
+
+    final safeIndex = updatedSections.isEmpty
+        ? 0
+        : currentIndex.value.clamp(0, updatedSections.length - 1);
+
+    sections.assignAll(updatedSections);
+    currentIndex.value = (safeIndex as num).toInt();
   }
 }

--- a/lib/presentation/features/home/screens/home_screen.dart
+++ b/lib/presentation/features/home/screens/home_screen.dart
@@ -8,6 +8,7 @@ import 'package:xpressatec/presentation/features/home/widgets/bottom_nav_bar.dar
 import 'package:xpressatec/presentation/features/home/widgets/custom_drawer.dart';
 import 'package:xpressatec/presentation/features/statistics/screens/statistics_screen.dart';
 import 'package:xpressatec/presentation/features/teacch_board/screens/teacch_board_screen.dart';
+
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
@@ -19,23 +20,29 @@ class HomeScreen extends StatelessWidget {
       appBar: AppBar(
         backgroundColor: Colors.white,
         title: Obx(() {
-          switch (navController.currentIndex.value) {
-            case 0: return const Text('Tablero TEACCH');
-            case 1: return const Text('Chat con Terapeuta');
-            case 2: return const Text('Personalización');
-            case 3: return const Text('Estadísticas');
-            default: return const Text('TEACCH App');
+          switch (navController.currentSection) {
+            case NavigationSection.teacch:
+              return const Text('Tablero TEACCH');
+            case NavigationSection.chat:
+              return const Text('Chat con Terapeuta');
+            case NavigationSection.customization:
+              return const Text('Personalización');
+            case NavigationSection.statistics:
+              return const Text('Estadísticas');
           }
         }),
       ),
       drawer: const CustomDrawer(),
       body: Obx(() {
-        switch (navController.currentIndex.value) {
-          case 0: return const TeacchBoardScreen();
-          case 1: return const ChatScreen();
-          case 2: return const CustomizationScreen();
-          case 3: return const StatisticsScreen();
-          default: return const TeacchBoardScreen();
+        switch (navController.currentSection) {
+          case NavigationSection.teacch:
+            return const TeacchBoardScreen();
+          case NavigationSection.chat:
+            return const ChatScreen();
+          case NavigationSection.customization:
+            return const CustomizationScreen();
+          case NavigationSection.statistics:
+            return const StatisticsScreen();
         }
       }),
       bottomNavigationBar: const BottomNavBar(),

--- a/lib/presentation/features/home/widgets/bottom_nav_bar.dart
+++ b/lib/presentation/features/home/widgets/bottom_nav_bar.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:xpressatec/core/theme/app_colors.dart';
 import 'package:xpressatec/presentation/features/home/controllers/navigation_controller.dart';
+
 class BottomNavBar extends StatelessWidget {
   const BottomNavBar({super.key});
 
@@ -10,34 +11,49 @@ class BottomNavBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final NavigationController controller = Get.find();
 
-    return Obx(() => NavigationBar(
-      selectedIndex: controller.currentIndex.value,
-      onDestinationSelected: controller.changePage,
-      indicatorColor: AppColors.secondary,
-      backgroundColor: Colors.white,
-      destinations: const [
-        NavigationDestination(
-          icon: Icon(Icons.dashboard_outlined),
-          selectedIcon: Icon(Icons.dashboard, color: Colors.white,),
-          label: 'Tablero',
-        ),
-        NavigationDestination(
-          icon: Icon(Icons.chat_bubble_outline),
-          selectedIcon: Icon(Icons.chat_bubble, color: Colors.white),
-          label: 'Chat',
-        ),
-        NavigationDestination(
-          icon: Icon(Icons.palette_outlined),
-          selectedIcon: Icon(Icons.palette, color: Colors.white),
-          label: 'Personalizar',
-        ),
-        NavigationDestination(
-          icon: Icon(Icons.bar_chart_outlined),
-          selectedIcon: Icon(Icons.bar_chart, color: Colors.white),
-          label: 'Estadísticas',
-        ),
-      ],
-    ));
+    return Obx(() {
+      final sections = controller.sections;
+      if (sections.isEmpty) {
+        return const SizedBox.shrink();
+      }
+
+      final selectedIndex =
+          controller.currentIndex.value.clamp(0, sections.length - 1);
+
+      return NavigationBar(
+        selectedIndex: (selectedIndex as num).toInt(),
+        onDestinationSelected: controller.changePage,
+        indicatorColor: AppColors.secondary,
+        backgroundColor: Colors.white,
+        destinations: sections.map((section) {
+          switch (section) {
+            case NavigationSection.teacch:
+              return const NavigationDestination(
+                icon: Icon(Icons.dashboard_outlined),
+                selectedIcon: Icon(Icons.dashboard, color: Colors.white),
+                label: 'Tablero',
+              );
+            case NavigationSection.chat:
+              return const NavigationDestination(
+                icon: Icon(Icons.chat_bubble_outline),
+                selectedIcon: Icon(Icons.chat_bubble, color: Colors.white),
+                label: 'Chat',
+              );
+            case NavigationSection.customization:
+              return const NavigationDestination(
+                icon: Icon(Icons.palette_outlined),
+                selectedIcon: Icon(Icons.palette, color: Colors.white),
+                label: 'Personalizar',
+              );
+            case NavigationSection.statistics:
+              return const NavigationDestination(
+                icon: Icon(Icons.bar_chart_outlined),
+                selectedIcon: Icon(Icons.bar_chart, color: Colors.white),
+                label: 'Estadísticas',
+              );
+          }
+        }).toList(),
+      );
+    });
   }
 }
-

--- a/lib/presentation/features/home/widgets/custom_drawer.dart
+++ b/lib/presentation/features/home/widgets/custom_drawer.dart
@@ -46,7 +46,7 @@ class CustomDrawer extends StatelessWidget {
           ),
           // Enlazar con Terapeuta (Destacado) - Solo mostrar para pacientes y tutores
           Obx(() {
-            if (authController.userRole.value.toLowerCase() != 'terapeuta') {
+            if (!authController.isTerapeuta) {
               return Container(
                 margin: const EdgeInsets.all(16),
                 decoration: BoxDecoration(


### PR DESCRIPTION
## Summary
- centralize role helpers in the auth controller
- drive home navigation tabs from the authenticated role and hide patient-only options
- guard chat initialization to prevent access from patients and keep the drawer role aware

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69102cba397c832fa46b5546ca8c7e9f)