### PR TITLE
Add tutor calendar screen and enhance TEACCH header

### DIFF
--- a/lib/core/bindings/tutor_calendar_binding.dart
+++ b/lib/core/bindings/tutor_calendar_binding.dart
@@ -1,0 +1,23 @@
+import 'package:get/get.dart';
+import 'package:xpressatec/data/repositories/mock_appointments_repository.dart';
+import 'package:xpressatec/domain/repositories/appointments_repository.dart';
+import 'package:xpressatec/presentation/features/auth/controllers/auth_controller.dart';
+import 'package:xpressatec/presentation/features/calendar/controllers/tutor_calendar_controller.dart';
+
+class TutorCalendarBinding extends Bindings {
+  @override
+  void dependencies() {
+    // Once the backend endpoint is ready this repository registration can be
+    // swapped for a remote implementation without touching the UI layer.
+    Get.lazyPut<AppointmentsRepository>(
+      () => MockAppointmentsRepository(),
+    );
+
+    Get.lazyPut<TutorCalendarController>(
+      () => TutorCalendarController(
+        Get.find<AppointmentsRepository>(),
+        Get.find<AuthController>(),
+      ),
+    );
+  }
+}

--- a/lib/core/config/routes.dart
+++ b/lib/core/config/routes.dart
@@ -2,10 +2,8 @@ import 'package:get/get_navigation/src/routes/get_route.dart';
 import 'package:xpressatec/core/bindings/auth_binding.dart';
 import 'package:xpressatec/core/bindings/home_binding.dart';
 import 'package:xpressatec/presentation/features/auth/screens/login_screen.dart';
-
+import 'package:xpressatec/presentation/features/calendar/screens/tutor_calendar_screen.dart';
 import 'package:xpressatec/presentation/features/home/screens/home_screen.dart';
-
-
 import 'package:xpressatec/presentation/features/settings/screens/about_screen.dart';
 import 'package:xpressatec/presentation/features/settings/screens/settings_screen.dart';
 import 'package:xpressatec/presentation/features/splash/screens/splash_screen.dart';
@@ -17,6 +15,7 @@ import '../../core/bindings/link_tutor_binding.dart';
 import '../../core/bindings/scan_qr_binding.dart';
 import '../../presentation/features/profile/screens/link_tutor_screen.dart';
 import '../../presentation/features/profile/screens/scan_qr_screen.dart';
+import '../../core/bindings/tutor_calendar_binding.dart';
 
 // Route constants
 class Routes {
@@ -30,6 +29,7 @@ class Routes {
   static const String settings = '/settings';
   static const String about = '/about';
   static const String scanQr = '/scan-qr';
+  static const String tutorCalendar = '/tutor-calendar';
  // static const String audioTesting = '/audio-testing';
 }
 
@@ -67,6 +67,11 @@ class AppRoutes {
       name: Routes.scanQr,
       page: () => const ScanQrScreen(),
       binding: ScanQrBinding(),
+    ),
+    GetPage(
+      name: Routes.tutorCalendar,
+      page: () => const TutorCalendarScreen(),
+      binding: TutorCalendarBinding(),
     ),
     GetPage(
       name: Routes.settings,

--- a/lib/data/repositories/mock_appointments_repository.dart
+++ b/lib/data/repositories/mock_appointments_repository.dart
@@ -1,0 +1,54 @@
+import 'dart:math';
+
+import 'package:xpressatec/domain/entities/appointment.dart';
+import 'package:xpressatec/domain/repositories/appointments_repository.dart';
+
+class MockAppointmentsRepository implements AppointmentsRepository {
+  MockAppointmentsRepository();
+
+  static final List<Appointment> _seedAppointments = _generateSeed();
+
+  @override
+  Future<List<Appointment>> getTutorAppointments({
+    required DateTime startDate,
+    required DateTime endDate,
+  }) async {
+    // In the future this method will perform a network call to the backend API.
+    // For now we simulate latency to keep the flow similar to the real scenario.
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+
+    final normalizedStart = DateTime(startDate.year, startDate.month, startDate.day);
+    final normalizedEnd = DateTime(endDate.year, endDate.month, endDate.day, 23, 59, 59);
+
+    return _seedAppointments
+        .where((appointment) =>
+            appointment.startTime.isAfter(normalizedStart.subtract(const Duration(seconds: 1))) &&
+            appointment.startTime.isBefore(normalizedEnd.add(const Duration(seconds: 1))))
+        .toList();
+  }
+
+  static List<Appointment> _generateSeed() {
+    final now = DateTime.now();
+    final random = Random(42);
+    final List<Appointment> appointments = [];
+
+    for (int i = -5; i <= 10; i++) {
+      final date = DateTime(now.year, now.month, now.day).add(Duration(days: i));
+      final dailyCount = random.nextInt(2);
+      for (int j = 0; j <= dailyCount; j++) {
+        final start = date.add(Duration(hours: 9 + j * 2));
+        appointments.add(
+          Appointment(
+            id: '${date.toIso8601String()}-$j',
+            startTime: start,
+            duration: const Duration(minutes: 45),
+            patientName: j % 2 == 0 ? 'Juan Pérez' : 'Ana López',
+            title: j % 2 == 0 ? 'Sesión de seguimiento' : 'Evaluación cognitiva',
+            notes: 'Mock data - replace with API response',
+          ),
+        );
+      }
+    }
+    return appointments;
+  }
+}

--- a/lib/domain/entities/appointment.dart
+++ b/lib/domain/entities/appointment.dart
@@ -1,0 +1,24 @@
+import 'package:equatable/equatable.dart';
+
+class Appointment extends Equatable {
+  final String id;
+  final DateTime startTime;
+  final Duration duration;
+  final String patientName;
+  final String title;
+  final String? notes;
+
+  const Appointment({
+    required this.id,
+    required this.startTime,
+    required this.duration,
+    required this.patientName,
+    required this.title,
+    this.notes,
+  });
+
+  DateTime get endTime => startTime.add(duration);
+
+  @override
+  List<Object?> get props => [id, startTime, duration, patientName, title, notes];
+}

--- a/lib/domain/repositories/appointments_repository.dart
+++ b/lib/domain/repositories/appointments_repository.dart
@@ -1,0 +1,12 @@
+import 'package:xpressatec/domain/entities/appointment.dart';
+
+abstract class AppointmentsRepository {
+  /// Retrieves the appointments for the authenticated tutor between the given range.
+  ///
+  /// The implementation will later connect to the backend API. For now the
+  /// data is mocked in memory.
+  Future<List<Appointment>> getTutorAppointments({
+    required DateTime startDate,
+    required DateTime endDate,
+  });
+}

--- a/lib/presentation/features/calendar/controllers/tutor_calendar_controller.dart
+++ b/lib/presentation/features/calendar/controllers/tutor_calendar_controller.dart
@@ -1,0 +1,127 @@
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+import 'package:xpressatec/domain/entities/appointment.dart';
+import 'package:xpressatec/domain/repositories/appointments_repository.dart';
+import 'package:xpressatec/presentation/features/auth/controllers/auth_controller.dart';
+
+class TutorCalendarController extends GetxController {
+  TutorCalendarController(
+    this._repository,
+    this._authController,
+  );
+
+  final AppointmentsRepository _repository;
+  final AuthController _authController;
+
+  final Rx<DateTime> focusedDay = DateTime.now().obs;
+  final Rx<DateTime> selectedDay = DateTime.now().obs;
+  final RxBool isLoading = false.obs;
+  final RxList<Appointment> appointments = <Appointment>[].obs;
+  final RxString errorMessage = ''.obs;
+
+  bool get isTutor => _authController.isTutor;
+
+  List<Appointment> get appointmentsForSelectedDay =>
+      appointmentsForDay(selectedDay.value);
+
+  List<Appointment> appointmentsForDay(DateTime day) => appointments
+      .where((appointment) => _isSameDay(appointment.startTime, day))
+      .toList()
+    ..sort((a, b) => a.startTime.compareTo(b.startTime));
+
+  @override
+  void onInit() {
+    super.onInit();
+    if (!isTutor) {
+      errorMessage.value = 'Esta sección es exclusiva para tutores.';
+      return;
+    }
+    _loadAppointmentsForVisibleRange();
+  }
+
+  Future<void> onRefresh() async {
+    await _loadAppointmentsForVisibleRange(forceReload: true);
+  }
+
+  Future<void> onDaySelected(DateTime selected, DateTime focused) async {
+    selectedDay.value = selected;
+    focusedDay.value = focused;
+
+    if (!_hasDataFor(selected)) {
+      await _loadAppointmentsForVisibleRange(reference: selected);
+    } else {
+      appointments.refresh();
+    }
+  }
+
+  Future<void> onPageChanged(DateTime focused) async {
+    focusedDay.value = focused;
+    await _loadAppointmentsForVisibleRange(reference: focused);
+  }
+
+  bool hasAppointmentsOn(DateTime day) {
+    return appointments.any((appointment) => _isSameDay(appointment.startTime, day));
+  }
+
+  Future<void> _loadAppointmentsForVisibleRange({
+    DateTime? reference,
+    bool forceReload = false,
+  }) async {
+    final DateTime base = reference ?? focusedDay.value;
+    final DateTime start = DateTime(base.year, base.month, 1);
+    final DateTime end = DateTime(base.year, base.month + 1, 0);
+
+    final shouldFetch = forceReload ||
+        appointments
+            .where((appointment) => _isWithinRange(appointment.startTime, start, end))
+            .isEmpty;
+
+    if (!shouldFetch) {
+      return;
+    }
+
+    try {
+      isLoading.value = true;
+      errorMessage.value = '';
+
+      final result = await _repository.getTutorAppointments(
+        startDate: start,
+        endDate: end,
+      );
+
+      appointments
+        ..removeWhere((appointment) => _isWithinRange(appointment.startTime, start, end))
+        ..addAll(result);
+
+      appointments.sort((a, b) => a.startTime.compareTo(b.startTime));
+    } catch (error) {
+      errorMessage.value =
+          'No pudimos cargar tus citas. Intenta nuevamente más tarde. (${error.toString()})';
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  bool _hasDataFor(DateTime day) {
+    return appointments.any((appointment) => _isSameDay(appointment.startTime, day));
+  }
+
+  bool _isSameDay(DateTime dateA, DateTime dateB) {
+    return dateA.year == dateB.year && dateA.month == dateB.month && dateA.day == dateB.day;
+  }
+
+  bool _isWithinRange(DateTime date, DateTime start, DateTime end) {
+    final normalized = DateTime(date.year, date.month, date.day);
+    final normalizedStart = DateTime(start.year, start.month, start.day);
+    final normalizedEnd = DateTime(end.year, end.month, end.day);
+    return (normalized.isAtSameMomentAs(normalizedStart) ||
+            normalized.isAfter(normalizedStart)) &&
+        (normalized.isAtSameMomentAs(normalizedEnd) ||
+            normalized.isBefore(normalizedEnd));
+  }
+
+  String formatTimeRange(Appointment appointment) {
+    final timeFormat = DateFormat('HH:mm');
+    return '${timeFormat.format(appointment.startTime)} - ${timeFormat.format(appointment.endTime)}';
+  }
+}

--- a/lib/presentation/features/calendar/screens/tutor_calendar_screen.dart
+++ b/lib/presentation/features/calendar/screens/tutor_calendar_screen.dart
@@ -1,0 +1,324 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:table_calendar/table_calendar.dart';
+import 'package:xpressatec/domain/entities/appointment.dart';
+import 'package:xpressatec/presentation/features/calendar/controllers/tutor_calendar_controller.dart';
+
+class TutorCalendarScreen extends GetView<TutorCalendarController> {
+  const TutorCalendarScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mis citas'),
+      ),
+      body: SafeArea(
+        child: Obx(() {
+          if (!controller.isTutor) {
+            return _UnauthorizedMessage(theme: theme);
+          }
+
+          return RefreshIndicator(
+            onRefresh: controller.onRefresh,
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+              children: [
+                _buildCalendar(theme, colorScheme),
+                const SizedBox(height: 24),
+                _AppointmentsList(theme: theme),
+              ],
+            ),
+          );
+        }),
+      ),
+    );
+  }
+
+  Widget _buildCalendar(ThemeData theme, ColorScheme colorScheme) {
+    return Obx(() {
+      return DecoratedBox(
+        decoration: BoxDecoration(
+          color: colorScheme.surface,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: [
+            BoxShadow(
+              color: colorScheme.primary.withOpacity(0.08),
+              blurRadius: 12,
+              offset: const Offset(0, 6),
+            ),
+          ],
+        ),
+        child: TableCalendar<Appointment>(
+          firstDay: DateTime.utc(2020, 1, 1),
+          lastDay: DateTime.utc(2030, 12, 31),
+          focusedDay: controller.focusedDay.value,
+          selectedDayPredicate: (day) =>
+              isSameDay(controller.selectedDay.value, day),
+          startingDayOfWeek: StartingDayOfWeek.monday,
+          locale: 'es_ES',
+          headerStyle: HeaderStyle(
+            formatButtonVisible: false,
+            titleCentered: true,
+            titleTextStyle: theme.textTheme.titleMedium!.copyWith(
+              color: colorScheme.primary,
+              fontWeight: FontWeight.bold,
+            ),
+            leftChevronIcon: Icon(Icons.chevron_left, color: colorScheme.primary),
+            rightChevronIcon: Icon(Icons.chevron_right, color: colorScheme.primary),
+          ),
+          calendarStyle: CalendarStyle(
+            todayDecoration: BoxDecoration(
+              color: colorScheme.primary.withOpacity(0.15),
+              shape: BoxShape.circle,
+            ),
+            selectedDecoration: BoxDecoration(
+              color: colorScheme.primary,
+              shape: BoxShape.circle,
+            ),
+            selectedTextStyle: theme.textTheme.bodyLarge?.copyWith(
+              color: colorScheme.onPrimary,
+            ),
+            todayTextStyle: theme.textTheme.bodyLarge?.copyWith(
+              color: colorScheme.primary,
+              fontWeight: FontWeight.w700,
+            ),
+            markerDecoration: BoxDecoration(
+              color: colorScheme.secondary,
+              shape: BoxShape.circle,
+            ),
+          ),
+          eventLoader: controller.appointmentsForDay,
+          onDaySelected: (selectedDay, focusedDay) {
+            controller.onDaySelected(selectedDay, focusedDay);
+          },
+          onPageChanged: (focusedDay) {
+            controller.onPageChanged(focusedDay);
+          },
+          availableCalendarFormats: const {CalendarFormat.month: 'Mes'},
+        ),
+      );
+    });
+  }
+}
+
+class _AppointmentsList extends GetView<TutorCalendarController> {
+  const _AppointmentsList({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = theme.colorScheme;
+
+    return Obx(() {
+      if (controller.errorMessage.isNotEmpty) {
+        return _ErrorState(theme: theme, message: controller.errorMessage.value);
+      }
+
+      final items = controller.appointmentsForSelectedDay;
+      final isLoading = controller.isLoading.value;
+
+      if (isLoading && items.isEmpty) {
+        return const Center(child: CircularProgressIndicator());
+      }
+
+      if (items.isEmpty) {
+        return Container(
+          padding: const EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            color: colorScheme.surface,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: colorScheme.outline.withOpacity(0.2)),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Sin citas programadas',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Selecciona otro día o vuelve más tarde para ver nuevas citas.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurface.withOpacity(0.7),
+                ),
+              ),
+            ],
+          ),
+        );
+      }
+
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (isLoading)
+            const Padding(
+              padding: EdgeInsets.only(bottom: 12),
+              child: LinearProgressIndicator(minHeight: 3),
+            ),
+          Text(
+            'Citas para el ${controller.selectedDay.value.day}/${controller.selectedDay.value.month}',
+            style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          ...items.map((appointment) => _AppointmentTile(
+                appointment: appointment,
+                theme: theme,
+                timeLabel: controller.formatTimeRange(appointment),
+              )),
+        ],
+      );
+    });
+  }
+}
+
+class _AppointmentTile extends StatelessWidget {
+  const _AppointmentTile({
+    required this.appointment,
+    required this.theme,
+    required this.timeLabel,
+  });
+
+  final Appointment appointment;
+  final ThemeData theme;
+  final String timeLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.primary.withOpacity(0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.access_time, color: colorScheme.primary),
+              const SizedBox(width: 8),
+              Text(
+                timeLabel,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            appointment.title,
+            style: theme.textTheme.titleLarge?.copyWith(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Paciente: ${appointment.patientName}',
+            style: theme.textTheme.bodyLarge,
+          ),
+          if (appointment.notes != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              appointment.notes!,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurface.withOpacity(0.7),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.theme, required this.message});
+
+  final ThemeData theme;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Ups…',
+            style: theme.textTheme.titleLarge?.copyWith(
+              color: colorScheme.onErrorContainer,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            message,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onErrorContainer,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _UnauthorizedMessage extends StatelessWidget {
+  const _UnauthorizedMessage({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = theme.colorScheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.lock_outline, size: 48, color: colorScheme.primary),
+            const SizedBox(height: 16),
+            Text(
+              'Acceso restringido',
+              style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Solo los tutores pueden acceder al calendario de citas.',
+              style: theme.textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/features/home/screens/home_screen.dart
+++ b/lib/presentation/features/home/screens/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 
 import 'package:get/get.dart';
 import 'package:xpressatec/presentation/features/chat/screens/chat_screen.dart';
@@ -15,6 +16,10 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final NavigationController navController = Get.find();
+    final theme = Theme.of(context);
+    final titleColor = theme.appBarTheme.titleTextStyle?.color ??
+        theme.textTheme.titleLarge?.color ??
+        theme.colorScheme.onSurface;
 
     return Scaffold(
       appBar: AppBar(
@@ -22,7 +27,25 @@ class HomeScreen extends StatelessWidget {
         title: Obx(() {
           switch (navController.currentSection) {
             case NavigationSection.teacch:
-              return const Text('Tablero TEACCH');
+              return Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Tablero',
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      color: titleColor,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  SvgPicture.asset(
+                    'assets/images/imagen.svg',
+                    height: 24,
+                    colorFilter: ColorFilter.mode(titleColor, BlendMode.srcIn),
+                    semanticsLabel: 'Icono del tablero TEACCH',
+                  ),
+                ],
+              );
             case NavigationSection.chat:
               return const Text('Chat con Terapeuta');
             case NavigationSection.customization:

--- a/lib/presentation/features/home/widgets/custom_drawer.dart
+++ b/lib/presentation/features/home/widgets/custom_drawer.dart
@@ -116,49 +116,93 @@ class CustomDrawer extends StatelessWidget {
           // Escanear QR - Solo mostrar para tutores
           Obx(() {
             if (authController.isTutor) {
-              return Container(
-                margin: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    colors: [
-                      colorScheme.primary,
-                      colorScheme.primaryContainer,
-                    ],
-                  ),
-                  borderRadius: BorderRadius.circular(12),
-                  boxShadow: [
-                    BoxShadow(
-                      color: colorScheme.primary.withOpacity(0.25),
-                      blurRadius: 8,
-                      offset: const Offset(0, 4),
-                    ),
-                  ],
-                ),
-                child: ListTile(
-                  onTap: () => Get.toNamed(Routes.scanQr),
-                  leading: Container(
-                    padding: const EdgeInsets.all(8),
+              return Column(
+                children: [
+                  Container(
+                    margin: const EdgeInsets.all(16),
                     decoration: BoxDecoration(
-                      color: colorScheme.onPrimary,
-                      borderRadius: BorderRadius.circular(8),
+                      gradient: LinearGradient(
+                        colors: [
+                          colorScheme.primary,
+                          colorScheme.primaryContainer,
+                        ],
+                      ),
+                      borderRadius: BorderRadius.circular(12),
+                      boxShadow: [
+                        BoxShadow(
+                          color: colorScheme.primary.withOpacity(0.25),
+                          blurRadius: 8,
+                          offset: const Offset(0, 4),
+                        ),
+                      ],
                     ),
-                    child: Icon(Icons.qr_code_scanner, color: colorScheme.primary),
-                  ),
-                  title: Text(
-                    'Escanear QR',
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      color: colorScheme.onPrimary,
-                      fontWeight: FontWeight.w700,
+                    child: ListTile(
+                      onTap: () => Get.toNamed(Routes.scanQr),
+                      leading: Container(
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: colorScheme.onPrimary,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Icon(Icons.qr_code_scanner, color: colorScheme.primary),
+                      ),
+                      title: Text(
+                        'Escanear QR',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: colorScheme.onPrimary,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      subtitle: Text(
+                        'Escanea el código del paciente para enlazar',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onPrimary.withOpacity(0.8),
+                        ),
+                      ),
+                      trailing: Icon(Icons.arrow_forward_ios, color: colorScheme.onPrimary),
                     ),
                   ),
-                  subtitle: Text(
-                    'Escanea el código del paciente para enlazar',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: colorScheme.onPrimary.withOpacity(0.8),
+                  const SizedBox(height: 12),
+                  Container(
+                    margin: const EdgeInsets.symmetric(horizontal: 16),
+                    decoration: BoxDecoration(
+                      color: colorScheme.surface,
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(color: colorScheme.primary.withOpacity(0.1)),
+                      boxShadow: [
+                        BoxShadow(
+                          color: colorScheme.primary.withOpacity(0.1),
+                          blurRadius: 6,
+                          offset: const Offset(0, 3),
+                        ),
+                      ],
+                    ),
+                    child: ListTile(
+                      onTap: () => Get.toNamed(Routes.tutorCalendar),
+                      leading: Container(
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: colorScheme.primary.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Icon(Icons.calendar_month, color: colorScheme.primary),
+                      ),
+                      title: Text(
+                        'Mis citas',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      subtitle: Text(
+                        'Consulta el calendario de sesiones programadas',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onSurface.withOpacity(0.7),
+                        ),
+                      ),
+                      trailing: Icon(Icons.arrow_forward_ios, color: colorScheme.primary),
                     ),
                   ),
-                  trailing: Icon(Icons.arrow_forward_ios, color: colorScheme.onPrimary),
-                ),
+                ],
               );
             }
             return const SizedBox.shrink();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter_chat_ui: ^2.9.1
   flutter_dotenv: ^6.0.0
   flutter_svg: ^2.2.1
+  table_calendar: ^3.0.9
   get: ^4.7.2
   hive_flutter: ^1.1.0
   http: ^1.5.0


### PR DESCRIPTION
## Summary
- replace the TEACCH board app bar title with a "Tablero" label and SVG icon to match the updated design
- add a tutor calendar feature with GetX controller, mock appointments repository, and calendar UI ready for backend integration
- register the new route/binding and expose the calendar entry in the tutor drawer menu

## Testing
- Not run (Flutter SDK not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69103bdca92c832f9c51e4d92027d8d7)