### PR TITLE
Fix localization delegate configuration and calendar text styles

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,7 +40,7 @@ class MyApp extends StatelessWidget {
         Locale('es', 'ES'),
       ],
       locale: const Locale('es', 'ES'),
-      localizationsDelegates: const [
+      localizationsDelegates: [
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,

--- a/lib/presentation/features/calendar/screens/tutor_calendar_screen.dart
+++ b/lib/presentation/features/calendar/screens/tutor_calendar_screen.dart
@@ -80,10 +80,12 @@ class TutorCalendarScreen extends GetView<TutorCalendarController> {
               color: colorScheme.primary,
               shape: BoxShape.circle,
             ),
-            selectedTextStyle: theme.textTheme.bodyLarge?.copyWith(
+            selectedTextStyle:
+                (theme.textTheme.bodyLarge ?? const TextStyle()).copyWith(
               color: colorScheme.onPrimary,
             ),
-            todayTextStyle: theme.textTheme.bodyLarge?.copyWith(
+            todayTextStyle:
+                (theme.textTheme.bodyLarge ?? const TextStyle()).copyWith(
               color: colorScheme.primary,
               fontWeight: FontWeight.w700,
             ),


### PR DESCRIPTION
## Summary
- adjust the GetMaterialApp localization delegate list to avoid const usage
- ensure TableCalendar text styles provide non-null fallbacks for required parameters

## Testing
- Not run (Flutter SDK not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691047204acc832f83a18b89e70050f9)