### PR TITLE
Update Link Tutor screen to use primary blue accents

### DIFF
--- a/lib/presentation/features/profile/screens/link_tutor_screen.dart
+++ b/lib/presentation/features/profile/screens/link_tutor_screen.dart
@@ -108,7 +108,11 @@ class LinkTutorScreen extends GetView<LinkTutorController> {
       width: double.infinity,
       padding: const EdgeInsets.symmetric(vertical: 48),
       decoration: _cardDecoration(colorScheme),
-      child: const Center(child: CircularProgressIndicator()),
+      child: Center(
+        child: CircularProgressIndicator(
+          valueColor: AlwaysStoppedAnimation(colorScheme.primary),
+        ),
+      ),
     );
   }
 
@@ -194,7 +198,11 @@ class _QrContent extends StatelessWidget {
           const SizedBox(height: 24),
           FilledButton.icon(
             onPressed: onRefresh,
-            icon: const Icon(Icons.refresh),
+            style: FilledButton.styleFrom(
+              backgroundColor: colorScheme.primary,
+              foregroundColor: colorScheme.onPrimary,
+            ),
+            icon: Icon(Icons.refresh, color: colorScheme.onPrimary),
             label: const Text('Actualizar código'),
           ),
         ],
@@ -249,7 +257,11 @@ class _ErrorState extends StatelessWidget {
           const SizedBox(height: 24),
           FilledButton.icon(
             onPressed: onRetry,
-            icon: const Icon(Icons.refresh),
+            style: FilledButton.styleFrom(
+              backgroundColor: colorScheme.primary,
+              foregroundColor: colorScheme.onPrimary,
+            ),
+            icon: Icon(Icons.refresh, color: colorScheme.onPrimary),
             label: const Text('Reintentar'),
           ),
         ],


### PR DESCRIPTION
## Summary
- ensure the loading state indicator adopts the screen's primary blue accent
- align the QR refresh and retry buttons with the primary color scheme for background and icons

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691161bc7b74832f9358ec665c7e1253)