### PR TITLE
Add communication therapist marketplace screen

### DIFF
--- a/lib/core/bindings/communication_therapist_binding.dart
+++ b/lib/core/bindings/communication_therapist_binding.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+
+import '../../presentation/features/therapists/controllers/communication_therapist_controller.dart';
+
+class CommunicationTherapistBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<CommunicationTherapistController>(
+      () => CommunicationTherapistController(),
+    );
+  }
+}

--- a/lib/core/config/routes.dart
+++ b/lib/core/config/routes.dart
@@ -7,10 +7,12 @@ import 'package:xpressatec/presentation/features/home/screens/home_screen.dart';
 import 'package:xpressatec/presentation/features/settings/screens/about_screen.dart';
 import 'package:xpressatec/presentation/features/settings/screens/settings_screen.dart';
 import 'package:xpressatec/presentation/features/splash/screens/splash_screen.dart';
+import 'package:xpressatec/presentation/features/therapists/screens/communication_therapist_marketplace_screen.dart';
 
 import '../../presentation/features/audio_testing/audio_testing_screen.dart';
 import '../../presentation/features/auth/screens/register_screen.dart';
 import '../../presentation/features/package_download/screens/package_download_screen.dart';
+import '../../core/bindings/communication_therapist_binding.dart';
 import '../../core/bindings/link_tutor_binding.dart';
 import '../../core/bindings/scan_qr_binding.dart';
 import '../../presentation/features/profile/screens/link_tutor_screen.dart';
@@ -30,7 +32,8 @@ class Routes {
   static const String about = '/about';
   static const String scanQr = '/scan-qr';
   static const String tutorCalendar = '/tutor-calendar';
- // static const String audioTesting = '/audio-testing';
+  static const String communicationTherapists = '/communication-therapists';
+  // static const String audioTesting = '/audio-testing';
 }
 
 class AppRoutes {
@@ -72,6 +75,11 @@ class AppRoutes {
       name: Routes.tutorCalendar,
       page: () => const TutorCalendarScreen(),
       binding: TutorCalendarBinding(),
+    ),
+    GetPage(
+      name: Routes.communicationTherapists,
+      page: () => const CommunicationTherapistMarketplaceScreen(),
+      binding: CommunicationTherapistBinding(),
     ),
     GetPage(
       name: Routes.settings,

--- a/lib/presentation/features/home/widgets/custom_drawer.dart
+++ b/lib/presentation/features/home/widgets/custom_drawer.dart
@@ -207,6 +207,16 @@ class CustomDrawer extends StatelessWidget {
             }
             return const SizedBox.shrink();
           }),
+          Obx(() {
+            if (authController.isTutor || authController.isPaciente) {
+              return ListTile(
+                leading: Icon(Icons.person_search, color: colorScheme.primary),
+                title: const Text('Buscar terapeuta'),
+                onTap: () => Get.toNamed(Routes.communicationTherapists),
+              );
+            }
+            return const SizedBox.shrink();
+          }),
           const Divider(),
           ListTile(
             leading: const Icon(Icons.settings),

--- a/lib/presentation/features/therapists/controllers/communication_therapist_controller.dart
+++ b/lib/presentation/features/therapists/controllers/communication_therapist_controller.dart
@@ -1,0 +1,76 @@
+import 'package:get/get.dart';
+
+import '../models/communication_therapist.dart';
+
+class CommunicationTherapistController extends GetxController {
+  CommunicationTherapistController();
+
+  /// TODO: Replace this mock list with data provided by a
+  /// [TherapistRepository] once the backend is available.
+  final RxList<CommunicationTherapist> therapists = <CommunicationTherapist>[
+    CommunicationTherapist(
+      nombre: 'Laura Fernández',
+      especialidad: 'Terapia de Lenguaje Infantil',
+      anosExperiencia: 8,
+      modalidad: 'Online',
+      ubicacion: 'Ciudad de México',
+      rating: 4.8,
+      tags: const ['Autismo', 'Infantil', 'TEACCH'],
+    ),
+    CommunicationTherapist(
+      nombre: 'Miguel Torres',
+      especialidad: 'Comunicación Aumentativa y Alternativa',
+      anosExperiencia: 12,
+      modalidad: 'Híbrido',
+      ubicacion: 'Guadalajara',
+      rating: 4.6,
+      tags: const ['CAA', 'Adultos', 'Tecnología Asistiva'],
+    ),
+    CommunicationTherapist(
+      nombre: 'Ana Beltrán',
+      especialidad: 'Rehabilitación del Habla',
+      anosExperiencia: 6,
+      modalidad: 'Presencial',
+      ubicacion: 'Monterrey',
+      rating: 4.9,
+      tags: const ['Neurológico', 'Adultos'],
+    ),
+    CommunicationTherapist(
+      nombre: 'Paola Jiménez',
+      especialidad: 'Lenguaje y Comunicación Temprana',
+      anosExperiencia: 5,
+      modalidad: 'Online',
+      ubicacion: 'Puebla',
+      rating: 4.7,
+      tags: const ['Infantil', 'Intervención Temprana'],
+    ),
+  ].obs;
+
+  final RxList<CommunicationTherapist> filteredTherapists =
+      <CommunicationTherapist>[].obs;
+
+  final RxString searchQuery = ''.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    filteredTherapists.assignAll(therapists);
+  }
+
+  void filterTherapists(String query) {
+    searchQuery.value = query;
+    if (query.isEmpty) {
+      filteredTherapists.assignAll(therapists);
+      return;
+    }
+
+    final lowerQuery = query.toLowerCase();
+    filteredTherapists.assignAll(
+      therapists.where(
+        (therapist) => therapist.nombre.toLowerCase().contains(lowerQuery) ||
+            therapist.especialidad.toLowerCase().contains(lowerQuery) ||
+            therapist.ubicacion.toLowerCase().contains(lowerQuery),
+      ),
+    );
+  }
+}

--- a/lib/presentation/features/therapists/models/communication_therapist.dart
+++ b/lib/presentation/features/therapists/models/communication_therapist.dart
@@ -1,0 +1,21 @@
+class CommunicationTherapist {
+  CommunicationTherapist({
+    required this.nombre,
+    required this.especialidad,
+    required this.anosExperiencia,
+    required this.modalidad,
+    required this.ubicacion,
+    required this.rating,
+    required this.tags,
+    this.fotoUrl,
+  });
+
+  final String nombre;
+  final String especialidad;
+  final int anosExperiencia;
+  final String modalidad;
+  final String ubicacion;
+  final double rating;
+  final List<String> tags;
+  final String? fotoUrl;
+}

--- a/lib/presentation/features/therapists/screens/communication_therapist_marketplace_screen.dart
+++ b/lib/presentation/features/therapists/screens/communication_therapist_marketplace_screen.dart
@@ -1,0 +1,551 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get/get.dart';
+
+import '../controllers/communication_therapist_controller.dart';
+import '../models/communication_therapist.dart';
+
+class CommunicationTherapistMarketplaceScreen extends GetView<CommunicationTherapistController> {
+  const CommunicationTherapistMarketplaceScreen({super.key});
+
+  @override
+  CommunicationTherapistController get controller =>
+      Get.find<CommunicationTherapistController>();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFE3F2FD),
+      appBar: AppBar(
+        centerTitle: true,
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: SvgPicture.asset(
+          'assets/images/imagen.svg',
+          height: 32,
+          semanticsLabel: 'Xpressatec',
+        ),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Terapeutas en comunicación',
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  color: colorScheme.primary,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Explora especialistas en comunicación y lenguaje.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurface.withOpacity(0.7),
+                ),
+              ),
+              const SizedBox(height: 20),
+              _SearchField(
+                onChanged: controller.filterTherapists,
+              ),
+              const SizedBox(height: 20),
+              Expanded(
+                child: Obx(() {
+                  final therapists = controller.filteredTherapists;
+
+                  if (therapists.isEmpty) {
+                    return _EmptyResultsMessage(
+                      query: controller.searchQuery.value,
+                      colorScheme: colorScheme,
+                    );
+                  }
+
+                  return ListView.separated(
+                    itemCount: therapists.length,
+                    separatorBuilder: (_, __) => const SizedBox(height: 16),
+                    itemBuilder: (context, index) {
+                      final therapist = therapists[index];
+                      return _TherapistCard(
+                        therapist: therapist,
+                        colorScheme: colorScheme,
+                        onTap: () => _showTherapistDetails(context, therapist),
+                      );
+                    },
+                  );
+                }),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showTherapistDetails(
+    BuildContext context,
+    CommunicationTherapist therapist,
+  ) {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (context) {
+        final theme = Theme.of(context);
+        final colorScheme = theme.colorScheme;
+
+        return Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  _TherapistAvatar(
+                    therapist: therapist,
+                    size: 56,
+                    colorScheme: colorScheme,
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          therapist.nombre,
+                          style: theme.textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          therapist.especialidad,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: colorScheme.primary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 20),
+              _DetailRow(
+                icon: Icons.location_on_outlined,
+                label: 'Ubicación',
+                value: therapist.ubicacion,
+              ),
+              _DetailRow(
+                icon: Icons.school_outlined,
+                label: 'Experiencia',
+                value: '${therapist.anosExperiencia} años',
+              ),
+              _DetailRow(
+                icon: Icons.computer_outlined,
+                label: 'Modalidad',
+                value: therapist.modalidad,
+              ),
+              _DetailRow(
+                icon: Icons.star_rounded,
+                label: 'Calificación',
+                value: therapist.rating.toStringAsFixed(1),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Especialidades y enfoques',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: therapist.tags
+                    .map(
+                      (tag) => Chip(
+                        label: Text(tag),
+                        backgroundColor: colorScheme.primary.withOpacity(0.1),
+                        labelStyle: theme.textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.primary,
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: () {
+                    // TODO: Integrar acción para contactar al terapeuta
+                    // cuando el backend y el TherapistRepository estén listos.
+                    Navigator.of(context).pop();
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: colorScheme.primary,
+                    foregroundColor: colorScheme.onPrimary,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                  ),
+                  icon: const Icon(Icons.send_rounded),
+                  label: const Text('Contactar (próximamente)'),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SearchField extends StatelessWidget {
+  const _SearchField({
+    required this.onChanged,
+  });
+
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return TextField(
+      onChanged: onChanged,
+      decoration: InputDecoration(
+        hintText: 'Buscar por nombre, ciudad o especialidad',
+        filled: true,
+        fillColor: Colors.white,
+        prefixIcon: Icon(Icons.search, color: colorScheme.primary),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(24),
+          borderSide: BorderSide(color: colorScheme.primary.withOpacity(0.2)),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(24),
+          borderSide: BorderSide(color: colorScheme.primary, width: 1.5),
+        ),
+      ),
+    );
+  }
+}
+
+class _TherapistCard extends StatelessWidget {
+  const _TherapistCard({
+    required this.therapist,
+    required this.colorScheme,
+    required this.onTap,
+  });
+
+  final CommunicationTherapist therapist;
+  final ColorScheme colorScheme;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(20),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          boxShadow: [
+            BoxShadow(
+              color: colorScheme.primary.withOpacity(0.12),
+              blurRadius: 12,
+              offset: const Offset(0, 6),
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _TherapistAvatar(
+                    therapist: therapist,
+                    colorScheme: colorScheme,
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          therapist.nombre,
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w700,
+                            color: colorScheme.onSurface,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          therapist.especialidad,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: colorScheme.primary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          children: [
+                            Icon(Icons.location_on_outlined,
+                                size: 18, color: colorScheme.primary),
+                            const SizedBox(width: 4),
+                            Expanded(
+                              child: Text(
+                                therapist.ubicacion,
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  color: colorScheme.onSurface.withOpacity(0.7),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          children: [
+                            _InfoChip(
+                              icon: Icons.school_outlined,
+                              label: '${therapist.anosExperiencia} años',
+                              colorScheme: colorScheme,
+                            ),
+                            const SizedBox(width: 8),
+                            _InfoChip(
+                              icon: Icons.computer_outlined,
+                              label: therapist.modalidad,
+                              colorScheme: colorScheme,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.star_rounded,
+                          color: colorScheme.secondary, size: 22),
+                      const SizedBox(width: 4),
+                      Text(
+                        therapist.rating.toStringAsFixed(1),
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: therapist.tags
+                    .map(
+                      (tag) => Chip(
+                        label: Text(tag),
+                        backgroundColor: colorScheme.primary.withOpacity(0.08),
+                        labelStyle: theme.textTheme.bodySmall?.copyWith(
+                          color: colorScheme.primary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TherapistAvatar extends StatelessWidget {
+  const _TherapistAvatar({
+    required this.therapist,
+    required this.colorScheme,
+    this.size = 64,
+  });
+
+  final CommunicationTherapist therapist;
+  final ColorScheme colorScheme;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final initials = therapist.nombre
+        .split(' ')
+        .where((part) => part.isNotEmpty)
+        .take(2)
+        .map((part) => part[0])
+        .join()
+        .toUpperCase();
+
+    return CircleAvatar(
+      radius: size / 2,
+      backgroundColor: colorScheme.primary.withOpacity(0.15),
+      backgroundImage:
+          therapist.fotoUrl != null ? AssetImage(therapist.fotoUrl!) : null,
+      child: therapist.fotoUrl == null
+          ? Text(
+              initials,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: colorScheme.primary,
+                  ),
+            )
+          : null,
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({
+    required this.icon,
+    required this.label,
+    required this.colorScheme,
+  });
+
+  final IconData icon;
+  final String label;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: colorScheme.primary.withOpacity(0.08),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: colorScheme.primary),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.primary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: colorScheme.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurface.withOpacity(0.6),
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  value,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyResultsMessage extends StatelessWidget {
+  const _EmptyResultsMessage({
+    required this.query,
+    required this.colorScheme,
+  });
+
+  final String query;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.search_off, size: 48, color: colorScheme.primary),
+          const SizedBox(height: 12),
+          Text(
+            'No encontramos terapeutas',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: colorScheme.primary,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            query.isEmpty
+                ? 'Intenta buscar por especialidad o ciudad.'
+                : 'No hay resultados para "$query". Prueba con otro término.',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.7),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add GetX binding, model, and controller to expose mock communication therapists
- build the communication therapist marketplace screen with search, light blue styling, and detail bottom sheet
- register the new route with a SVG app bar and surface it from the drawer navigation

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691168fcfbf0832fb1fc3c6e5d372d4d)