### PR TITLE
Reorganize personalization access and add pictogram download flow

### DIFF
--- a/lib/core/config/routes.dart
+++ b/lib/core/config/routes.dart
@@ -5,6 +5,7 @@ import 'package:xpressatec/presentation/features/auth/screens/login_screen.dart'
 import 'package:xpressatec/presentation/features/calendar/screens/tutor_calendar_screen.dart';
 import 'package:xpressatec/presentation/features/home/screens/home_screen.dart';
 import 'package:xpressatec/presentation/features/settings/screens/about_screen.dart';
+import 'package:xpressatec/presentation/features/settings/screens/download_pictograms_screen.dart';
 import 'package:xpressatec/presentation/features/settings/screens/settings_screen.dart';
 import 'package:xpressatec/presentation/features/splash/screens/splash_screen.dart';
 import 'package:xpressatec/presentation/features/therapists/screens/communication_therapist_marketplace_screen.dart';
@@ -12,6 +13,7 @@ import 'package:xpressatec/presentation/features/therapists/screens/communicatio
 import '../../presentation/features/audio_testing/audio_testing_screen.dart';
 import '../../presentation/features/auth/screens/register_screen.dart';
 import '../../presentation/features/package_download/screens/package_download_screen.dart';
+import '../../presentation/features/customization/screens/customization_screen.dart';
 import '../../core/bindings/communication_therapist_binding.dart';
 import '../../core/bindings/link_tutor_binding.dart';
 import '../../core/bindings/scan_qr_binding.dart';
@@ -30,6 +32,8 @@ class Routes {
   static const String linkTutor = '/link-tutor';
   static const String settings = '/settings';
   static const String about = '/about';
+  static const String customization = '/customization';
+  static const String downloadPictograms = '/download-pictograms';
   static const String scanQr = '/scan-qr';
   static const String tutorCalendar = '/tutor-calendar';
   static const String communicationTherapists = '/communication-therapists';
@@ -88,6 +92,14 @@ class AppRoutes {
     GetPage(
       name: Routes.about,
       page: () => const AboutScreen(),
+    ),
+    GetPage(
+      name: Routes.customization,
+      page: () => const CustomizationScreen(),
+    ),
+    GetPage(
+      name: Routes.downloadPictograms,
+      page: () => const DownloadPictogramsScreen(),
     ),
 
     // GetPage(

--- a/lib/presentation/features/home/controllers/navigation_controller.dart
+++ b/lib/presentation/features/home/controllers/navigation_controller.dart
@@ -2,13 +2,12 @@ import 'package:get/get.dart';
 import 'package:xpressatec/domain/entities/user.dart';
 import 'package:xpressatec/presentation/features/auth/controllers/auth_controller.dart';
 
-enum NavigationSection { teacch, chat, customization, statistics }
+enum NavigationSection { teacch, chat, statistics }
 
 class NavigationController extends GetxController {
   final RxInt currentIndex = 0.obs;
   final RxList<NavigationSection> sections = <NavigationSection>[
     NavigationSection.teacch,
-    NavigationSection.customization,
     NavigationSection.statistics,
   ].obs;
 
@@ -43,7 +42,6 @@ class NavigationController extends GetxController {
     final updatedSections = <NavigationSection>[
       NavigationSection.teacch,
       if (isTutor || isTerapeuta) NavigationSection.chat,
-      NavigationSection.customization,
       NavigationSection.statistics,
     ];
 

--- a/lib/presentation/features/home/screens/home_screen.dart
+++ b/lib/presentation/features/home/screens/home_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_svg/flutter_svg.dart';
 
 import 'package:get/get.dart';
 import 'package:xpressatec/presentation/features/chat/screens/chat_screen.dart';
-import 'package:xpressatec/presentation/features/customization/screens/customization_screen.dart';
 import 'package:xpressatec/presentation/features/home/controllers/navigation_controller.dart';
 import 'package:xpressatec/presentation/features/home/widgets/bottom_nav_bar.dart';
 import 'package:xpressatec/presentation/features/home/widgets/custom_drawer.dart';
@@ -47,8 +46,6 @@ class HomeScreen extends StatelessWidget {
               );
             case NavigationSection.chat:
               return const Text('Chat con Terapeuta');
-            case NavigationSection.customization:
-              return const Text('Personalización');
             case NavigationSection.statistics:
               return const Text('Estadísticas');
           }
@@ -61,8 +58,6 @@ class HomeScreen extends StatelessWidget {
             return const TeacchBoardScreen();
           case NavigationSection.chat:
             return const ChatScreen();
-          case NavigationSection.customization:
-            return const CustomizationScreen();
           case NavigationSection.statistics:
             return const StatisticsScreen();
         }

--- a/lib/presentation/features/home/widgets/bottom_nav_bar.dart
+++ b/lib/presentation/features/home/widgets/bottom_nav_bar.dart
@@ -39,12 +39,6 @@ class BottomNavBar extends StatelessWidget {
                 selectedIcon: Icon(Icons.chat_bubble, color: Colors.white),
                 label: 'Chat',
               );
-            case NavigationSection.customization:
-              return const NavigationDestination(
-                icon: Icon(Icons.palette_outlined),
-                selectedIcon: Icon(Icons.palette, color: Colors.white),
-                label: 'Personalizar',
-              );
             case NavigationSection.statistics:
               return const NavigationDestination(
                 icon: Icon(Icons.bar_chart_outlined),

--- a/lib/presentation/features/home/widgets/custom_drawer.dart
+++ b/lib/presentation/features/home/widgets/custom_drawer.dart
@@ -128,12 +128,12 @@ class CustomDrawer extends StatelessWidget {
           ListTile(
             leading: const Icon(Icons.settings),
             title: const Text('Ajustes'),
-            onTap: () => Get.toNamed('/settings'),
+            onTap: () => Get.toNamed(Routes.settings),
           ),
           ListTile(
             leading: const Icon(Icons.info_outline),
             title: const Text('Acerca de'),
-            onTap: () => Get.toNamed('/about'),
+            onTap: () => Get.toNamed(Routes.about),
           ),
           ListTile(
             leading: const Icon(Icons.mic, color: Colors.orange),

--- a/lib/presentation/features/settings/screens/download_pictograms_screen.dart
+++ b/lib/presentation/features/settings/screens/download_pictograms_screen.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get/get.dart';
+
+import '../../../customization/controllers/customization_controller.dart';
+
+class DownloadPictogramsScreen extends StatefulWidget {
+  const DownloadPictogramsScreen({super.key});
+
+  @override
+  State<DownloadPictogramsScreen> createState() =>
+      _DownloadPictogramsScreenState();
+}
+
+class _DownloadPictogramsScreenState extends State<DownloadPictogramsScreen> {
+  late final CustomizationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = Get.find<CustomizationController>();
+    _controller.refreshDownloadStatus();
+  }
+
+  Future<void> _handleDownload() async {
+    final status = await _controller.downloadPictogramsIfNeeded(
+      showProgressDialog: false,
+      showFeedback: false,
+    );
+
+    if (!mounted) return;
+
+    switch (status) {
+      case PictogramDownloadStatus.alreadyDownloaded:
+        Get.snackbar(
+          'Pictogramas disponibles',
+          'Los pictogramas ya están descargados en este dispositivo.',
+          snackPosition: SnackPosition.BOTTOM,
+        );
+        break;
+      case PictogramDownloadStatus.success:
+        Get.snackbar(
+          'Descarga exitosa',
+          'Pictogramas descargados correctamente.',
+          snackPosition: SnackPosition.BOTTOM,
+        );
+        break;
+      case PictogramDownloadStatus.failure:
+        Get.snackbar(
+          'Error',
+          'Ocurrió un error al descargar los pictogramas. Intenta nuevamente.',
+          snackPosition: SnackPosition.BOTTOM,
+        );
+        break;
+    }
+
+    await _controller.refreshDownloadStatus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.white10,
+        iconTheme: const IconThemeData(color: Colors.black),
+        centerTitle: true,
+        title: SvgPicture.asset(
+          'assets/images/imagen.svg',
+          height: 180,
+        ),
+      ),
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              Colors.white,
+              colorScheme.surface,
+            ],
+          ),
+        ),
+        child: SafeArea(
+          child: Center(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+              child: Obx(() {
+                final bool isDownloading = _controller.isDownloading.value;
+                final bool downloaded =
+                    _controller.assetsReady.value || _controller.hasDownloadedPictograms;
+                final bool failed = _controller.downloadFailed.value;
+                final int total = _controller.totalCount.value;
+                final int completed = _controller.downloadedCount.value;
+                final double? progress = total == 0 ? null : completed / total;
+
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Descargar pictogramas',
+                      style: theme.textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: Colors.black,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'Para personalizar tu experiencia, puedes descargar los pictogramas desde el servidor a tu almacenamiento local. Solo es necesario hacerlo una vez.',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: colorScheme.onSurface,
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                    Container(
+                      width: double.infinity,
+                      decoration: _cardDecoration(colorScheme),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 24,
+                        vertical: 32,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (downloaded)
+                            _buildStatusBanner(
+                              colorScheme,
+                              icon: Icons.check_circle,
+                              background: colorScheme.primary.withOpacity(0.1),
+                              iconColor: colorScheme.primary,
+                              text:
+                                  'Los pictogramas ya están descargados en este dispositivo.',
+                            )
+                          else if (failed)
+                            _buildStatusBanner(
+                              colorScheme,
+                              icon: Icons.error_outline,
+                              background: colorScheme.error.withOpacity(0.1),
+                              iconColor: colorScheme.error,
+                              text:
+                                  'Ocurrió un error al descargar los pictogramas. Intenta nuevamente.',
+                            )
+                          else
+                            _buildStatusBanner(
+                              colorScheme,
+                              icon: Icons.cloud_download_outlined,
+                              background: colorScheme.primary.withOpacity(0.08),
+                              iconColor: colorScheme.primary,
+                              text:
+                                  'Descarga los pictogramas para usarlos sin conexión.',
+                            ),
+                          if (isDownloading) ...[
+                            const SizedBox(height: 24),
+                            LinearProgressIndicator(value: progress),
+                            const SizedBox(height: 12),
+                            Text(
+                              total == 0
+                                  ? 'Preparando descarga...'
+                                  : '$completed de $total pictogramas',
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: colorScheme.onSurface,
+                              ),
+                            ),
+                          ],
+                          const SizedBox(height: 24),
+                          FilledButton.icon(
+                            onPressed:
+                                (!isDownloading && !downloaded) ? _handleDownload : null,
+                            style: FilledButton.styleFrom(
+                              backgroundColor: Colors.lightBlue,
+                              foregroundColor: Colors.white,
+                              minimumSize: const Size.fromHeight(48),
+                            ),
+                            icon: const Icon(Icons.download),
+                            label: Text(
+                              downloaded
+                                  ? 'Pictogramas ya descargados'
+                                  : 'Descargar pictogramas',
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                );
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  BoxDecoration _cardDecoration(ColorScheme colorScheme) {
+    return BoxDecoration(
+      color: colorScheme.surface,
+      borderRadius: BorderRadius.circular(24),
+      boxShadow: [
+        BoxShadow(
+          color: colorScheme.primary.withOpacity(0.18),
+          blurRadius: 16,
+          offset: const Offset(0, 8),
+        ),
+      ],
+      border: Border.all(
+        color: colorScheme.primary.withOpacity(0.35),
+        width: 1.4,
+      ),
+    );
+  }
+
+  Widget _buildStatusBanner(
+    ColorScheme colorScheme, {
+    required IconData icon,
+    required Color background,
+    required Color iconColor,
+    required String text,
+  }) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: iconColor),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              text,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurface,
+                  ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/features/settings/screens/settings_screen.dart
+++ b/lib/presentation/features/settings/screens/settings_screen.dart
@@ -12,43 +12,78 @@ class SettingsScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Ajustes')),
       body: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 12),
         children: [
-          ListTile(
-            leading: const Icon(Icons.notifications),
+          _buildSectionTitle(context, 'Preferencias'),
+          SwitchListTile(
+            secondary: const Icon(Icons.notifications_outlined),
             title: const Text('Notificaciones'),
-            trailing: Switch(value: true, onChanged: (_) {}),
+            value: true,
+            onChanged: (_) {},
           ),
           ListTile(
             leading: const Icon(Icons.language),
             title: const Text('Idioma'),
             trailing: const Text('Español'),
+            onTap: () {},
           ),
-          ListTile(
-            leading: const Icon(Icons.dark_mode),
+          SwitchListTile(
+            secondary: const Icon(Icons.dark_mode_outlined),
             title: const Text('Tema oscuro'),
-            trailing: Switch(value: false, onChanged: (_) {}),
+            value: false,
+            onChanged: (_) {},
           ),
           const Divider(),
+          _buildSectionTitle(context, 'Experiencia'),
           ListTile(
-            leading: const Icon(Icons.privacy_tip),
+            leading: const Icon(Icons.palette_outlined),
+            title: const Text('Personalización'),
+            subtitle: const Text('Gestiona tus pictogramas locales'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Get.toNamed(Routes.customization),
+          ),
+          ListTile(
+            leading: const Icon(Icons.download_for_offline_outlined),
+            title: const Text('Descargar pictogramas'),
+            subtitle:
+                const Text('Guarda los pictogramas en el dispositivo'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Get.toNamed(Routes.downloadPictograms),
+          ),
+          const Divider(),
+          _buildSectionTitle(context, 'Soporte'),
+          ListTile(
+            leading: const Icon(Icons.privacy_tip_outlined),
             title: const Text('Privacidad'),
+            onTap: () {},
           ),
           ListTile(
-            leading: const Icon(Icons.help),
+            leading: const Icon(Icons.help_outline),
             title: const Text('Ayuda'),
+            onTap: () {},
           ),
-
-          // Add this widget in your SettingsScreen build method:
-
           ListTile(
             leading: const Icon(Icons.download),
-            title: const Text('Descargar Paquetes de Audio'),
+            title: const Text('Descargar paquetes de audio'),
             subtitle: const Text('Gestionar voces de asistentes'),
-            onTap: () {
-              Get.toNamed(Routes.packageDownload);
-            },
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Get.toNamed(Routes.packageDownload),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildSectionTitle(BuildContext context, String title) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Text(
+        title,
+        style: theme.textTheme.titleMedium?.copyWith(
+          fontWeight: FontWeight.w600,
+          color: theme.colorScheme.primary,
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- remove the personalization section from the home navigation and expose it through Settings instead
- add a dedicated "Descargar pictogramas" entry and confirmation screen that reuses the existing customization controller to manage downloads and gating
- extend the customization controller and routes to support download status checks, a new pictogram download flow, and Settings UI refinements

## Testing
- not run (Flutter SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69116f9612f8832fa6c97607b8ad3015)