### PR TITLE
Refine settings experience layouts

### DIFF
--- a/lib/presentation/features/customization/screens/customization_screen.dart
+++ b/lib/presentation/features/customization/screens/customization_screen.dart
@@ -1,46 +1,56 @@
+import 'package:animated_tree_view/animated_tree_view.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:animated_tree_view/animated_tree_view.dart';
 import 'package:xpressatec/core/constants/app_constants.dart';
 import 'package:xpressatec/presentation/features/customization/controllers/customization_controller.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/utils/category_mapper.dart';
+import '../../settings/widgets/settings_detail_layout.dart';
 
 class CustomizationScreen extends GetView<CustomizationController> {
   const CustomizationScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white,
-      body: Obx(() {
-        final refreshKey = controller.treeRefreshToken.value;
-        return FutureBuilder<TreeNode<CategoryData>>(
-          key: ValueKey(refreshKey),
-          future: _loadCategories(),
-          builder: (context, snapshot) {
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return const Center(
-                child: CircularProgressIndicator(),
-              );
-            }
+    final colorScheme = Theme.of(context).colorScheme;
 
-            if (snapshot.hasError) {
-              return Center(
-                child: Text('Error: ${snapshot.error}'),
-              );
-            }
+    return SettingsDetailLayout(
+      title: 'Personalización',
+      subtitle: 'Gestiona tus pictogramas locales y categorías.',
+      expandChild: true,
+      child: Container(
+        width: double.infinity,
+        decoration: SettingsDetailLayout.cardDecoration(colorScheme),
+        padding: const EdgeInsets.all(16),
+        child: Obx(() {
+          final refreshKey = controller.treeRefreshToken.value;
+          return FutureBuilder<TreeNode<CategoryData>>(
+            key: ValueKey(refreshKey),
+            future: _loadCategories(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(
+                  child: CircularProgressIndicator(),
+                );
+              }
 
-            if (!snapshot.hasData || snapshot.data!.children.isEmpty) {
-              return const Center(
-                child: Text('No hay categorías disponibles'),
-              );
-            }
+              if (snapshot.hasError) {
+                return Center(
+                  child: Text('Error: ${snapshot.error}'),
+                );
+              }
 
-            return _buildTreeView(context, snapshot.data!);
-          },
-        );
-      }),
+              if (!snapshot.hasData || snapshot.data!.children.isEmpty) {
+                return const Center(
+                  child: Text('No hay categorías disponibles'),
+                );
+              }
+
+              return _buildTreeView(context, snapshot.data!);
+            },
+          );
+        }),
+      ),
     );
   }
 

--- a/lib/presentation/features/package_download/screens/package_download_screen.dart
+++ b/lib/presentation/features/package_download/screens/package_download_screen.dart
@@ -2,161 +2,159 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:xpressatec/presentation/features/package_download/controllers/audio_package_controller.dart';
 
+import '../../settings/widgets/settings_detail_layout.dart';
+
 class PackageDownloadScreen extends StatelessWidget {
   const PackageDownloadScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     final controller = Get.find<AudioPackageController>();
+    final colorScheme = Theme.of(context).colorScheme;
 
-    return Scaffold(
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(24.0),
-          child: Obx(() {
-            // Show loading while checking available assistants
-            if (controller.isChecking.value) {
-              return const Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    CircularProgressIndicator(),
-                    SizedBox(height: 16),
-                    Text('Verificando paquetes disponibles...'),
-                  ],
-                ),
-              );
-            }
+    return SettingsDetailLayout(
+      title: 'Descargar paquetes de audio',
+      subtitle:
+          'Gestiona las voces disponibles para tus asistentes y mantenlas listas sin conexión.',
+      child: Obx(() {
+        return Container(
+          width: double.infinity,
+          decoration: SettingsDetailLayout.cardDecoration(colorScheme),
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+          child: _buildContent(context, controller, colorScheme),
+        );
+      }),
+    );
+  }
 
-            // Show download UI
-            return Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Icon
-                Icon(
-                  Icons.download_rounded,
-                  size: 80,
-                  color: Theme.of(context).primaryColor,
-                ),
-                const SizedBox(height: 24),
-
-                // Title
-                const Text(
-                  'Descarga de Paquete de Audio',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 16),
-
-                // Description
-                const Text(
-                  'Para optimizar el rendimiento, descarga el paquete de audio de tu asistente preferido.',
-                  style: TextStyle(fontSize: 16),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 32),
-
-                // Assistant selector (only if multiple available)
-                if (controller.availableAssistants.length > 1) ...[
-                  const Text(
-                    'Selecciona un asistente:',
-                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
-                  ),
-                  const SizedBox(height: 12),
-                  Wrap(
-                    spacing: 8,
-                    children: controller.availableAssistants.map((assistant) {
-                      final isSelected = controller.selectedAssistant.value == assistant;
-                      return ChoiceChip(
-                        label: Text(assistant),
-                        selected: isSelected,
-                        onSelected: controller.isDownloading.value
-                            ? null
-                            : (selected) {
-                          if (selected) {
-                            controller.selectedAssistant.value = assistant;
-                          }
-                        },
-                      );
-                    }).toList(),
-                  ),
-                  const SizedBox(height: 32),
-                ],
-
-                // Download progress
-                if (controller.isDownloading.value) ...[
-                  LinearProgressIndicator(
-                    value: controller.downloadProgress.value,
-                    minHeight: 8,
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    'Descargando ${controller.currentFile.value} de ${controller.totalFiles.value}',
-                    style: const TextStyle(fontSize: 14),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    controller.currentWord.value,
-                    style: const TextStyle(
-                      fontSize: 12,
-                      color: Colors.grey,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 32),
-                ],
-
-                // Error message
-                if (controller.errorMessage.isNotEmpty) ...[
-                  Container(
-                    padding: const EdgeInsets.all(12),
-                    decoration: BoxDecoration(
-                      color: Colors.red.shade50,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: Text(
-                      controller.errorMessage.value,
-                      style: TextStyle(color: Colors.red.shade900),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                ],
-
-                // Download button
-                ElevatedButton.icon(
-                  onPressed: controller.isDownloading.value
-                      ? null
-                      : () => controller.downloadPackage(),
-                  icon: const Icon(Icons.download),
-                  label: Text(
-                    controller.isDownloading.value
-                        ? 'Descargando...'
-                        : 'Descargar Paquete',
-                  ),
-                  style: ElevatedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(vertical: 16),
-                  ),
-                ),
-                const SizedBox(height: 12),
-
-                // Skip button
-                TextButton(
-                  onPressed: controller.isDownloading.value
-                      ? null
-                      : () => controller.skipDownload(),
-                  child: const Text('Omitir (descargar después)'),
-                ),
-              ],
-            );
-          }),
+  Widget _buildContent(
+    BuildContext context,
+    AudioPackageController controller,
+    ColorScheme colorScheme,
+  ) {
+    if (controller.isChecking.value) {
+      return const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(),
+            SizedBox(height: 16),
+            Text('Verificando paquetes disponibles...'),
+          ],
         ),
-      ),
+      );
+    }
+
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Align(
+          alignment: Alignment.center,
+          child: Icon(
+            Icons.download_rounded,
+            size: 72,
+            color: colorScheme.primary,
+          ),
+        ),
+        const SizedBox(height: 24),
+        Text(
+          'Descarga el paquete de audio de tu asistente preferido y úsalo sin conexión.',
+          style: theme.textTheme.bodyLarge?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 24),
+        if (controller.availableAssistants.length > 1) ...[
+          Text(
+            'Selecciona un asistente:',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: colorScheme.onSurface,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: controller.availableAssistants.map((assistant) {
+              final isSelected = controller.selectedAssistant.value == assistant;
+              return ChoiceChip(
+                label: Text(assistant),
+                selected: isSelected,
+                onSelected: controller.isDownloading.value
+                    ? null
+                    : (selected) {
+                        if (selected) {
+                          controller.selectedAssistant.value = assistant;
+                        }
+                      },
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: 24),
+        ],
+        if (controller.isDownloading.value) ...[
+          LinearProgressIndicator(
+            value: controller.downloadProgress.value,
+            minHeight: 8,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Descargando ${controller.currentFile.value} de ${controller.totalFiles.value}',
+            style: theme.textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            controller.currentWord.value,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+        ],
+        if (controller.errorMessage.isNotEmpty) ...[
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: colorScheme.error.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Text(
+              controller.errorMessage.value,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.error,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+          const SizedBox(height: 16),
+        ],
+        FilledButton.icon(
+          onPressed:
+              controller.isDownloading.value ? null : controller.downloadPackage,
+          icon: const Icon(Icons.download),
+          label: Text(
+            controller.isDownloading.value
+                ? 'Descargando...'
+                : 'Descargar paquete',
+          ),
+          style: FilledButton.styleFrom(
+            padding: const EdgeInsets.symmetric(vertical: 16),
+          ),
+        ),
+        const SizedBox(height: 12),
+        TextButton(
+          onPressed:
+              controller.isDownloading.value ? null : controller.skipDownload,
+          child: const Text('Omitir (descargar después)'),
+        ),
+      ],
     );
   }
 }

--- a/lib/presentation/features/settings/screens/settings_screen.dart
+++ b/lib/presentation/features/settings/screens/settings_screen.dart
@@ -50,6 +50,13 @@ class SettingsScreen extends StatelessWidget {
             trailing: const Icon(Icons.chevron_right),
             onTap: () => Get.toNamed(Routes.downloadPictograms),
           ),
+          ListTile(
+            leading: const Icon(Icons.headset_mic_outlined),
+            title: const Text('Descargar paquetes de audio'),
+            subtitle: const Text('Gestionar voces de asistentes'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Get.toNamed(Routes.packageDownload),
+          ),
           const Divider(),
           _buildSectionTitle(context, 'Soporte'),
           ListTile(
@@ -61,13 +68,6 @@ class SettingsScreen extends StatelessWidget {
             leading: const Icon(Icons.help_outline),
             title: const Text('Ayuda'),
             onTap: () {},
-          ),
-          ListTile(
-            leading: const Icon(Icons.download),
-            title: const Text('Descargar paquetes de audio'),
-            subtitle: const Text('Gestionar voces de asistentes'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => Get.toNamed(Routes.packageDownload),
           ),
         ],
       ),

--- a/lib/presentation/features/settings/widgets/settings_detail_layout.dart
+++ b/lib/presentation/features/settings/widgets/settings_detail_layout.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+class SettingsDetailLayout extends StatelessWidget {
+  const SettingsDetailLayout({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.child,
+    this.expandChild = false,
+  });
+
+  final String title;
+  final String subtitle;
+  final Widget child;
+  final bool expandChild;
+
+  static BoxDecoration cardDecoration(ColorScheme colorScheme) {
+    return BoxDecoration(
+      color: colorScheme.surface,
+      borderRadius: BorderRadius.circular(24),
+      boxShadow: [
+        BoxShadow(
+          color: colorScheme.primary.withOpacity(0.18),
+          blurRadius: 16,
+          offset: const Offset(0, 8),
+        ),
+      ],
+      border: Border.all(
+        color: colorScheme.primary.withOpacity(0.35),
+        width: 1.4,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: const BackButton(),
+        title: Text(title),
+      ),
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              Colors.white,
+              colorScheme.surface,
+            ],
+          ),
+        ),
+        child: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  subtitle,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                if (expandChild)
+                  Expanded(child: child)
+                else
+                  Flexible(
+                    child: SingleChildScrollView(
+                      child: SizedBox(
+                        width: double.infinity,
+                        child: child,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- group audio package downloads inside the new Experiencia section of Settings
- add a shared detail layout with back navigation for personalization and audio download screens
- align the customization and audio package flows with consistent headers, gradients, and cards

## Testing
- not run (flutter not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117364d13c832fbd754d59bbce01b9)