### PR TITLE
feat: redesign drawer menu cards

### DIFF
--- a/lib/presentation/features/home/widgets/custom_drawer.dart
+++ b/lib/presentation/features/home/widgets/custom_drawer.dart
@@ -4,6 +4,8 @@ import 'package:get/get.dart';
 import 'package:xpressatec/core/config/routes.dart';
 import 'package:xpressatec/presentation/features/auth/controllers/auth_controller.dart';
 
+import 'drawer_action_card.dart';
+
 class CustomDrawer extends StatelessWidget {
   const CustomDrawer({super.key});
 
@@ -24,7 +26,7 @@ class CustomDrawer extends StatelessWidget {
             decoration: BoxDecoration(
               gradient: LinearGradient(
                 colors: [
-                 Colors.lightBlue,
+                  Colors.lightBlue,
                   colorScheme.primaryContainer,
                 ],
                 begin: Alignment.topLeft,
@@ -68,56 +70,59 @@ class CustomDrawer extends StatelessWidget {
             if (authController.isPaciente) {
               return Padding(
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-                child: DrawerMenuItem(
-                  icon: Icons.link,
-                  label: 'Enlazar tutor',
+                child: DrawerActionCard(
+                  leadingIcon: Icons.link,
+                  title: 'Enlazar tutor',
                   subtitle: 'Comparte tu código QR con tu tutor',
-                  isActive: Get.currentRoute == Routes.linkTutor,
                   onTap: () => Get.toNamed(Routes.linkTutor),
                 ),
-              );
-            } else {
-              return const SizedBox.shrink();
-            }
-          }),
-          // Escanear QR y Mis citas - Solo mostrar para tutores
-          Obx(() {
-            if (authController.isTutor) {
-              return Column(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-                    child: DrawerMenuItem(
-                      icon: Icons.qr_code_scanner,
-                      label: 'Escanear QR',
-                      subtitle: 'Escanea el código del paciente para enlazar',
-                      isActive: Get.currentRoute == Routes.scanQr,
-                      onTap: () => Get.toNamed(Routes.scanQr),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-                    child: DrawerMenuItem(
-                      icon: Icons.event_note,
-                      label: 'Mis citas',
-                      subtitle: 'Consulta el calendario de sesiones programadas',
-                      isActive: Get.currentRoute == Routes.tutorCalendar,
-                      onTap: () => Get.toNamed(Routes.tutorCalendar),
-                    ),
-                  ),
-                ],
               );
             }
             return const SizedBox.shrink();
           }),
+          // Escanear QR y Mis citas - Mostrar según rol
           Obx(() {
-            if (authController.isTutor || authController.isPaciente) {
+            final bool showScan = authController.isTutor;
+            final bool showAppointments =
+                authController.isTutor || authController.isTerapeuta;
+
+            if (!showScan && !showAppointments) {
+              return const SizedBox.shrink();
+            }
+
+            return Column(
+              children: [
+                if (showScan)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                    child: DrawerActionCard(
+                      leadingIcon: Icons.qr_code_scanner,
+                      title: 'Escanear QR',
+                      subtitle: 'Escanea el código del paciente',
+                      onTap: () => Get.toNamed(Routes.scanQr),
+                    ),
+                  ),
+                if (showAppointments)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                    child: DrawerActionCard(
+                      leadingIcon: Icons.event,
+                      title: 'Mis citas',
+                      subtitle: 'Revisa tu agenda de sesiones',
+                      onTap: () => Get.toNamed(Routes.tutorCalendar),
+                    ),
+                  ),
+              ],
+            );
+          }),
+          Obx(() {
+            if (authController.isTutor || authController.isTerapeuta) {
               return Padding(
                 padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-                child: DrawerMenuItem(
-                  icon: Icons.person_search,
-                  label: 'Buscar terapeuta',
-                  isActive: Get.currentRoute == Routes.communicationTherapists,
+                child: DrawerActionCard(
+                  leadingIcon: Icons.person_search,
+                  title: 'Buscar terapeutas',
+                  subtitle: 'Explora terapeutas en comunicación',
                   onTap: () => Get.toNamed(Routes.communicationTherapists),
                 ),
               );
@@ -149,88 +154,6 @@ class CustomDrawer extends StatelessWidget {
           ),
 
         ],
-      ),
-    );
-  }
-}
-
-class DrawerMenuItem extends StatelessWidget {
-  const DrawerMenuItem({
-    super.key,
-    required this.icon,
-    required this.label,
-    required this.onTap,
-    this.isActive = false,
-    this.subtitle,
-  });
-
-  final IconData icon;
-  final String label;
-  final VoidCallback onTap;
-  final bool isActive;
-  final String? subtitle;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final Color activeColor = colorScheme.primary;
-    final Color inactiveColor = colorScheme.onSurface.withOpacity(0.8);
-    final Color foregroundColor = isActive ? activeColor : inactiveColor;
-    final Color subtitleColor = isActive
-        ? activeColor.withOpacity(0.8)
-        : colorScheme.onSurface.withOpacity(0.6);
-
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(16),
-        child: Container(
-          decoration: BoxDecoration(
-            color: isActive ? activeColor.withOpacity(0.08) : Colors.transparent,
-            borderRadius: BorderRadius.circular(16),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            crossAxisAlignment:
-                subtitle != null ? CrossAxisAlignment.start : CrossAxisAlignment.center,
-            children: [
-              Icon(icon, color: foregroundColor),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      label,
-                      style: theme.textTheme.titleMedium?.copyWith(
-                        color: foregroundColor,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    if (subtitle != null)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 4),
-                        child: Text(
-                          subtitle!,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: subtitleColor,
-                          ),
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-              Icon(
-                Icons.arrow_forward_ios,
-                size: 16,
-                color: foregroundColor,
-              ),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/lib/presentation/features/home/widgets/drawer_action_card.dart
+++ b/lib/presentation/features/home/widgets/drawer_action_card.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+
+class DrawerActionCard extends StatelessWidget {
+  const DrawerActionCard({
+    super.key,
+    required this.leadingIcon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+    this.gradientColors,
+  });
+
+  final IconData leadingIcon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+  final List<Color>? gradientColors;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final List<Color> colors = gradientColors ??
+        [
+          colorScheme.primary,
+          Color.lerp(colorScheme.primary, colorScheme.primaryContainer, 0.6)!,
+        ];
+
+    final Color foregroundColor = colorScheme.onPrimary;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(24),
+        child: Ink(
+          height: 76,
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: colors,
+              begin: Alignment.centerLeft,
+              end: Alignment.centerRight,
+            ),
+            borderRadius: BorderRadius.circular(24),
+            boxShadow: [
+              BoxShadow(
+                color: colors.last.withOpacity(0.25),
+                blurRadius: 12,
+                offset: const Offset(0, 6),
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Container(
+                  width: 48,
+                  height: 48,
+                  decoration: BoxDecoration(
+                    color: foregroundColor,
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: Icon(
+                    leadingIcon,
+                    color: colorScheme.primary,
+                    size: 26,
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: foregroundColor,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        subtitle,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: foregroundColor.withOpacity(0.85),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Icon(
+                  Icons.chevron_right,
+                  color: foregroundColor,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable DrawerActionCard widget to deliver the new gradient card styling
- restyle drawer actions for tutor linking, QR scan, appointments, and therapist search with role-based visibility updates

## Testing
- not run (UI change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911799d9f58832fb967f4522162c657)