### PR TITLE
Add shared branding header across app screens

### DIFF
--- a/lib/presentation/features/auth/screens/register_screen.dart
+++ b/lib/presentation/features/auth/screens/register_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
 import 'package:xpressatec/presentation/features/auth/controllers/auth_controller.dart';
+import 'package:xpressatec/presentation/shared/widgets/xpressatec_header.dart';
 
 class RegisterScreen extends GetView<AuthController> {
   const RegisterScreen({super.key});
@@ -24,12 +24,10 @@ class RegisterScreen extends GetView<AuthController> {
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        backgroundColor: Colors.transparent,
+        automaticallyImplyLeading: true,
         elevation: 0,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: Colors.black87),
-          onPressed: () => Get.back(),
-        ),
+        backgroundColor: Colors.transparent,
+        foregroundColor: Theme.of(context).colorScheme.onSurface,
       ),
       body: SafeArea(
         // Use LayoutBuilder to create a responsive layout
@@ -84,11 +82,7 @@ class RegisterScreen extends GetView<AuthController> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            // Icon
-            SvgPicture.asset(
-              "assets/images/app_logo.svg",
-              height: 120, // Adjusted for a more balanced look
-            ),
+            const XpressatecHeader(),
             const SizedBox(height: 24),
 
             // Title

--- a/lib/presentation/features/calendar/screens/tutor_calendar_screen.dart
+++ b/lib/presentation/features/calendar/screens/tutor_calendar_screen.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'package:xpressatec/domain/entities/appointment.dart';
 import 'package:xpressatec/presentation/features/calendar/controllers/tutor_calendar_controller.dart';
+import '../../../shared/widgets/xpressatec_header.dart';
 
 class TutorCalendarScreen extends GetView<TutorCalendarController> {
   const TutorCalendarScreen({super.key});
@@ -14,12 +15,29 @@ class TutorCalendarScreen extends GetView<TutorCalendarController> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Mis citas'),
+        automaticallyImplyLeading: true,
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        foregroundColor: theme.colorScheme.onSurface,
       ),
       body: SafeArea(
         child: Obx(() {
           if (!controller.isTutor) {
-            return _UnauthorizedMessage(theme: theme);
+            return ListView(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+              children: [
+                const XpressatecHeader(),
+                const SizedBox(height: 16),
+                Text(
+                  'Mis citas',
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                _UnauthorizedMessage(theme: theme),
+              ],
+            );
           }
 
           return RefreshIndicator(
@@ -28,6 +46,15 @@ class TutorCalendarScreen extends GetView<TutorCalendarController> {
               physics: const AlwaysScrollableScrollPhysics(),
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
               children: [
+                const XpressatecHeader(),
+                const SizedBox(height: 16),
+                Text(
+                  'Mis citas',
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 24),
                 _buildCalendar(theme, colorScheme),
                 const SizedBox(height: 24),
                 _AppointmentsList(theme: theme),

--- a/lib/presentation/features/home/screens/home_screen.dart
+++ b/lib/presentation/features/home/screens/home_screen.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
-
 import 'package:get/get.dart';
 import 'package:xpressatec/presentation/features/chat/screens/chat_screen.dart';
 import 'package:xpressatec/presentation/features/home/controllers/navigation_controller.dart';
@@ -16,53 +14,36 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final NavigationController navController = Get.find();
     final theme = Theme.of(context);
-    final titleColor = theme.appBarTheme.titleTextStyle?.color ??
-        theme.textTheme.titleLarge?.color ??
-        theme.colorScheme.onSurface;
 
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Colors.white,
-        title: Obx(() {
-          switch (navController.currentSection) {
-            case NavigationSection.teacch:
-              return Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    '',
-                    style: theme.textTheme.titleLarge?.copyWith(
-                      color: titleColor,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  SvgPicture.asset(
-                    'assets/images/imagen.svg',
-                    height: 200,
-                    semanticsLabel: 'Icono del tablero TEACCH',
-                  ),
-                ],
-              );
-            case NavigationSection.chat:
-              return const Text('Chat con Terapeuta');
-            case NavigationSection.statistics:
-              return const Text('Estadísticas');
-          }
-        }),
-      ),
-      drawer: const CustomDrawer(),
-      body: Obx(() {
-        switch (navController.currentSection) {
-          case NavigationSection.teacch:
-            return const TeacchBoardScreen();
-          case NavigationSection.chat:
-            return const ChatScreen();
-          case NavigationSection.statistics:
-            return const StatisticsScreen();
-        }
-      }),
-      bottomNavigationBar: const BottomNavBar(),
-    );
+    return Obx(() {
+      final section = navController.currentSection;
+      Widget body;
+
+      switch (section) {
+        case NavigationSection.teacch:
+          body = const TeacchBoardScreen();
+          break;
+        case NavigationSection.chat:
+          body = const ChatScreen();
+          break;
+        case NavigationSection.statistics:
+          body = const StatisticsScreen();
+          break;
+      }
+
+      return Scaffold(
+        appBar: section == NavigationSection.chat
+            ? null
+            : AppBar(
+                automaticallyImplyLeading: true,
+                elevation: 0,
+                backgroundColor: Colors.transparent,
+                foregroundColor: theme.colorScheme.onSurface,
+              ),
+        drawer: const CustomDrawer(),
+        body: body,
+        bottomNavigationBar: const BottomNavBar(),
+      );
+    });
   }
 }

--- a/lib/presentation/features/package_download/screens/package_download_screen.dart
+++ b/lib/presentation/features/package_download/screens/package_download_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 
 import '../../settings/widgets/download_status_card.dart';
 import '../controllers/audio_package_controller.dart';
+import '../../../shared/widgets/xpressatec_header.dart';
 
 class PackageDownloadScreen extends StatefulWidget {
   const PackageDownloadScreen({super.key});
@@ -38,13 +38,10 @@ class _PackageDownloadScreenState extends State<PackageDownloadScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Colors.white10,
-        iconTheme: const IconThemeData(color: Colors.black),
-        centerTitle: true,
-        title: SvgPicture.asset(
-          'assets/images/imagen.svg',
-          height: 180,
-        ),
+        automaticallyImplyLeading: true,
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        foregroundColor: theme.colorScheme.onSurface,
       ),
       body: Container(
         decoration: BoxDecoration(
@@ -197,6 +194,8 @@ class _PackageDownloadScreenState extends State<PackageDownloadScreen> {
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    const XpressatecHeader(),
+                    const SizedBox(height: 16),
                     Text(
                       'Descargar paquetes de audio',
                       style: theme.textTheme.headlineSmall?.copyWith(

--- a/lib/presentation/features/profile/screens/link_tutor_screen.dart
+++ b/lib/presentation/features/profile/screens/link_tutor_screen.dart
@@ -1,10 +1,10 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 
 import '../controllers/link_tutor_controller.dart';
+import '../../../shared/widgets/xpressatec_header.dart';
 
 class LinkTutorScreen extends GetView<LinkTutorController> {
   const LinkTutorScreen({super.key});
@@ -16,14 +16,10 @@ class LinkTutorScreen extends GetView<LinkTutorController> {
 
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Colors.white10,
-        iconTheme: IconThemeData(color: Colors.black),
-        centerTitle: true,
-        title: SvgPicture.asset(
-          'assets/images/imagen.svg',
-          height: 200,
-        
-        ),
+        automaticallyImplyLeading: true,
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        foregroundColor: theme.colorScheme.onSurface,
       ),
       body: Container(
         decoration: BoxDecoration(
@@ -44,6 +40,8 @@ class LinkTutorScreen extends GetView<LinkTutorController> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  const XpressatecHeader(),
+                  const SizedBox(height: 16),
                   Text(
                     'Enlazar tutor',
                     style: theme.textTheme.headlineSmall?.copyWith(

--- a/lib/presentation/features/profile/screens/scan_qr_screen.dart
+++ b/lib/presentation/features/profile/screens/scan_qr_screen.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../controllers/scan_qr_controller.dart';
+import '../../../shared/widgets/xpressatec_header.dart';
 
 class ScanQrScreen extends GetView<ScanQrController> {
   const ScanQrScreen({super.key});
@@ -13,7 +14,12 @@ class ScanQrScreen extends GetView<ScanQrController> {
     final colorScheme = theme.colorScheme;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Escanear QR'), centerTitle: true),
+      appBar: AppBar(
+        automaticallyImplyLeading: true,
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        foregroundColor: theme.colorScheme.onSurface,
+      ),
       body: Container(
         decoration: BoxDecoration(
           gradient: LinearGradient(
@@ -28,14 +34,22 @@ class ScanQrScreen extends GetView<ScanQrController> {
         child: SafeArea(
           child: Column(
             children: [
+              const XpressatecHeader(),
+              const SizedBox(height: 16),
               Padding(
-                padding: const EdgeInsets.fromLTRB(24, 24, 24, 12),
+                padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
                 child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
+                      'Escanear QR',
+                      style: theme.textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
                       'Escanea el código del paciente para ver su información.',
-                      textAlign: TextAlign.center,
                       style: theme.textTheme.titleMedium?.copyWith(
                         fontWeight: FontWeight.w600,
                         color: colorScheme.onSurface,
@@ -44,7 +58,6 @@ class ScanQrScreen extends GetView<ScanQrController> {
                     const SizedBox(height: 8),
                     Text(
                       'Apunta la cámara hacia el código QR y mantenla estable hasta que se detecte.',
-                      textAlign: TextAlign.center,
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: colorScheme.onSurfaceVariant,
                       ),

--- a/lib/presentation/features/settings/screens/about_screen.dart
+++ b/lib/presentation/features/settings/screens/about_screen.dart
@@ -1,39 +1,57 @@
 import 'package:flutter/material.dart';
 
+import '../../../shared/widgets/xpressatec_header.dart';
+
 class AboutScreen extends StatelessWidget {
   const AboutScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('About'),
+        automaticallyImplyLeading: true,
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        foregroundColor: theme.colorScheme.onSurface,
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: const [
-            Text(
-              'Xpressatec',
-              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-            ),
-            SizedBox(height: 16),
-            Text(
-              'Version 1.0.0',
-              style: TextStyle(fontSize: 16),
-            ),
-            SizedBox(height: 16),
-            Text(
-              'Xpressatec is a platform designed to enhance your productivity and streamline your workflow.',
-              style: TextStyle(fontSize: 16),
-            ),
-            SizedBox(height: 24),
-            Text(
-              '© 2024 Xpressatec. All rights reserved.',
-              style: TextStyle(fontSize: 14, color: Colors.grey),
-            ),
-          ],
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const XpressatecHeader(),
+              const SizedBox(height: 16),
+              Text(
+                'About',
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                'Xpressatec',
+                style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                'Version 1.0.0',
+                style: TextStyle(fontSize: 16),
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                'Xpressatec is a platform designed to enhance your productivity and streamline your workflow.',
+                style: TextStyle(fontSize: 16),
+              ),
+              const SizedBox(height: 24),
+              const Text(
+                '© 2024 Xpressatec. All rights reserved.',
+                style: TextStyle(fontSize: 14, color: Colors.grey),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/features/settings/screens/download_pictograms_screen.dart
+++ b/lib/presentation/features/settings/screens/download_pictograms_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 
 import 'package:xpressatec/presentation/features/customization/controllers/customization_controller.dart';
 import 'package:xpressatec/presentation/features/settings/widgets/download_status_card.dart';
+import '../../../shared/widgets/xpressatec_header.dart';
 
 class DownloadPictogramsScreen extends StatefulWidget {
   const DownloadPictogramsScreen({super.key});
@@ -65,13 +65,10 @@ class _DownloadPictogramsScreenState extends State<DownloadPictogramsScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Colors.white10,
-        iconTheme: const IconThemeData(color: Colors.black),
-        centerTitle: true,
-        title: SvgPicture.asset(
-          'assets/images/imagen.svg',
-          height: 180,
-        ),
+        automaticallyImplyLeading: true,
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        foregroundColor: theme.colorScheme.onSurface,
       ),
       body: Container(
         decoration: BoxDecoration(
@@ -100,6 +97,8 @@ class _DownloadPictogramsScreenState extends State<DownloadPictogramsScreen> {
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    const XpressatecHeader(),
+                    const SizedBox(height: 16),
                     Text(
                       'Descargar pictogramas',
                       style: theme.textTheme.headlineSmall?.copyWith(

--- a/lib/presentation/features/settings/screens/settings_screen.dart
+++ b/lib/presentation/features/settings/screens/settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../../../../core/config/routes.dart';
+import '../../../shared/widgets/xpressatec_header.dart';
 
 
 class SettingsScreen extends StatelessWidget {
@@ -9,12 +10,32 @@ class SettingsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Ajustes')),
-      body: ListView(
-        padding: const EdgeInsets.symmetric(vertical: 12),
-        children: [
-          _buildSectionTitle(context, 'Preferencias'),
+      appBar: AppBar(
+        automaticallyImplyLeading: true,
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        foregroundColor: theme.colorScheme.onSurface,
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          children: [
+            const XpressatecHeader(),
+            const SizedBox(height: 16),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Text(
+                'Ajustes',
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            _buildSectionTitle(context, 'Preferencias'),
           SwitchListTile(
             secondary: const Icon(Icons.notifications_outlined),
             title: const Text('Notificaciones'),

--- a/lib/presentation/features/settings/widgets/settings_detail_layout.dart
+++ b/lib/presentation/features/settings/widgets/settings_detail_layout.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../../shared/widgets/xpressatec_header.dart';
+
 class SettingsDetailLayout extends StatelessWidget {
   const SettingsDetailLayout({
     super.key,
@@ -39,8 +41,10 @@ class SettingsDetailLayout extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        leading: const BackButton(),
-        title: Text(title),
+        automaticallyImplyLeading: true,
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        foregroundColor: theme.colorScheme.onSurface,
       ),
       body: Container(
         decoration: BoxDecoration(
@@ -59,6 +63,8 @@ class SettingsDetailLayout extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                const XpressatecHeader(),
+                const SizedBox(height: 16),
                 Text(
                   title,
                   style: theme.textTheme.headlineSmall?.copyWith(

--- a/lib/presentation/features/statistics/screens/statistics_screen.dart
+++ b/lib/presentation/features/statistics/screens/statistics_screen.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:xpressatec/presentation/features/statistics/controllers/statistics_controller.dart';
-import 'package:xpressatec/presentation/features/statistics/widgets/overview_cards.dart';
-import 'package:xpressatec/presentation/features/statistics/widgets/timeline_chart_widget.dart';
-import 'package:xpressatec/presentation/features/statistics/widgets/top_words_chart_widget.dart';
 import 'package:xpressatec/presentation/features/statistics/widgets/category_pie_chart_widget.dart';
+import 'package:xpressatec/presentation/features/statistics/widgets/overview_cards.dart';
 import 'package:xpressatec/presentation/features/statistics/widgets/recent_phrases_list.dart';
 import 'package:xpressatec/presentation/features/statistics/widgets/time_range_selector.dart';
+import 'package:xpressatec/presentation/features/statistics/widgets/timeline_chart_widget.dart';
+import 'package:xpressatec/presentation/features/statistics/widgets/top_words_chart_widget.dart';
+import 'package:xpressatec/presentation/shared/widgets/xpressatec_header.dart';
 
 class StatisticsScreen extends StatelessWidget {
   const StatisticsScreen({Key? key}) : super(key: key);
@@ -15,10 +16,44 @@ class StatisticsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final controller = Get.find<StatisticsController>();
 
+    Widget buildContent({
+      required List<Widget> children,
+      bool enableRefresh = false,
+    }) {
+      final scrollView = SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const XpressatecHeader(),
+              const SizedBox(height: 16),
+              _buildPageTitle(context),
+              const SizedBox(height: 16),
+              ...children,
+            ],
+          ),
+        ),
+      );
+
+      if (enableRefresh) {
+        return RefreshIndicator(
+          onRefresh: () => controller.refresh(),
+          child: scrollView,
+        );
+      }
+
+      return scrollView;
+    }
+
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        backgroundColor: Colors.white,
+        automaticallyImplyLeading: true,
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        foregroundColor: Theme.of(context).colorScheme.onSurface,
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
@@ -26,114 +61,114 @@ class StatisticsScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: Obx(() {
-        // Loading state
-        if (controller.isLoading.value) {
-          return const Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                CircularProgressIndicator(),
-                SizedBox(height: 16),
-                Text('Cargando estadísticas...'),
+      body: SafeArea(
+        child: Obx(() {
+          if (controller.isLoading.value) {
+            return buildContent(
+              children: const [
+                SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      CircularProgressIndicator(),
+                      SizedBox(height: 16),
+                      Text('Cargando estadísticas...'),
+                    ],
+                  ),
+                ),
               ],
-            ),
+            );
+          }
+
+          if (controller.errorMessage.isNotEmpty) {
+            return buildContent(
+              children: [
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(Icons.error_outline,
+                          size: 64, color: Colors.red),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Error: ${controller.errorMessage.value}',
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: () => controller.refresh(),
+                        child: const Text('Reintentar'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            );
+          }
+
+          if (controller.allPhrases.isEmpty) {
+            return buildContent(
+              enableRefresh: true,
+              children: [
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: Column(
+                    children: [
+                      Icon(Icons.analytics_outlined,
+                          size: 64, color: Colors.grey[400]),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Aún no hay frases guardadas',
+                        style:
+                            TextStyle(fontSize: 18, color: Colors.grey[600]),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Genera y guarda frases para ver tus estadísticas',
+                        style: TextStyle(color: Colors.grey[500]),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            );
+          }
+
+          return buildContent(
+            enableRefresh: true,
+            children: [
+              TimeRangeSelector(
+                selectedRange: controller.selectedTimeRange.value,
+                onChanged: (range) => controller.changeTimeRange(range),
+              ),
+              const SizedBox(height: 16),
+              OverviewCards(statistics: controller.statistics.value),
+              const SizedBox(height: 24),
+              _buildSectionTitle('Actividad'),
+              const SizedBox(height: 12),
+              TimelineChartWidget(statistics: controller.statistics.value),
+              const SizedBox(height: 24),
+              _buildSectionTitle('Palabras Más Usadas'),
+              const SizedBox(height: 12),
+              TopWordsChartWidget(statistics: controller.statistics.value),
+              const SizedBox(height: 24),
+              _buildSectionTitle('Uso por Categoría'),
+              const SizedBox(height: 12),
+              CategoryPieChartWidget(statistics: controller.statistics.value),
+              const SizedBox(height: 24),
+              _buildSectionTitle('Frases Recientes'),
+              const SizedBox(height: 12),
+              RecentPhrasesList(phrases: controller.filteredPhrases),
+            ],
           );
-        }
-
-        // Error state
-        if (controller.errorMessage.isNotEmpty) {
-          return Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                const Icon(Icons.error_outline, size: 64, color: Colors.red),
-                const SizedBox(height: 16),
-                Text(
-                  'Error: ${controller.errorMessage.value}',
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 16),
-                ElevatedButton(
-                  onPressed: () => controller.refresh(),
-                  child: const Text('Reintentar'),
-                ),
-              ],
-            ),
-          );
-        }
-
-        // Empty state
-        if (controller.allPhrases.isEmpty) {
-          return Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(Icons.analytics_outlined,
-                    size: 64, color: Colors.grey[400]),
-                const SizedBox(height: 16),
-                Text(
-                  'Aún no hay frases guardadas',
-                  style: TextStyle(fontSize: 18, color: Colors.grey[600]),
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  'Genera y guarda frases para ver tus estadísticas',
-                  style: TextStyle(color: Colors.grey[500]),
-                  textAlign: TextAlign.center,
-                ),
-              ],
-            ),
-          );
-        }
-
-        // Statistics Dashboard
-        return RefreshIndicator(
-          onRefresh: () => controller.refresh(),
-          child: SingleChildScrollView(
-            physics: const AlwaysScrollableScrollPhysics(),
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // Time Range Selector
-                TimeRangeSelector(
-                  selectedRange: controller.selectedTimeRange.value,
-                  onChanged: (range) => controller.changeTimeRange(range),
-                ),
-                const SizedBox(height: 16),
-
-                // Overview Cards
-                OverviewCards(statistics: controller.statistics.value),
-                const SizedBox(height: 24),
-
-                // Timeline Chart
-                _buildSectionTitle('Actividad'),
-                const SizedBox(height: 12),
-                TimelineChartWidget(statistics: controller.statistics.value),
-                const SizedBox(height: 24),
-
-                // Top Words Chart
-                _buildSectionTitle('Palabras Más Usadas'),
-                const SizedBox(height: 12),
-                TopWordsChartWidget(statistics: controller.statistics.value),
-                const SizedBox(height: 24),
-
-                // Category Pie Chart
-                _buildSectionTitle('Uso por Categoría'),
-                const SizedBox(height: 12),
-                CategoryPieChartWidget(statistics: controller.statistics.value),
-                const SizedBox(height: 24),
-
-                // Recent Phrases
-                _buildSectionTitle('Frases Recientes'),
-                const SizedBox(height: 12),
-                RecentPhrasesList(phrases: controller.filteredPhrases),
-              ],
-            ),
-          ),
-        );
-      }),
+        }),
+      ),
     );
   }
 
@@ -144,6 +179,15 @@ class StatisticsScreen extends StatelessWidget {
         fontSize: 20,
         fontWeight: FontWeight.bold,
       ),
+    );
+  }
+
+  Widget _buildPageTitle(BuildContext context) {
+    return Text(
+      'Estadísticas',
+      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
     );
   }
 }

--- a/lib/presentation/features/teacch_board/screens/teacch_board_screen.dart
+++ b/lib/presentation/features/teacch_board/screens/teacch_board_screen.dart
@@ -4,6 +4,7 @@ import 'package:xpressatec/core/constants/app_constants.dart';
 
 import 'package:xpressatec/presentation/features/teacch_board/controllers/teacch_controller.dart';
 import 'package:xpressatec/presentation/features/teacch_board/widgets/category_detail_sheet.dart';
+import 'package:xpressatec/presentation/shared/widgets/xpressatec_header.dart';
 import '../controllers/tts_controller.dart';
 import '../widgets/board_grid.dart';
 import '../widgets/selected_items_bar.dart';
@@ -48,17 +49,21 @@ class TeacchBoardScreen extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: Colors.white,
-      body: Column(
-        children: [
-          // ✨ Scrollable selected items bar (only visible when items are selected)
-          SelectedItemsBar(),
-
-          Expanded(
-            child: BoardGrid(
-              cards: categoryCards,
+      body: SafeArea(
+        child: Column(
+          children: [
+            const XpressatecHeader(),
+            const SizedBox(height: 16),
+            // ✨ Scrollable selected items bar (only visible when items are selected)
+            SelectedItemsBar(),
+            const SizedBox(height: 16),
+            Expanded(
+              child: BoardGrid(
+                cards: categoryCards,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
 
       // ✨ NEW: Floating Action Button (visible only with 2+ items)

--- a/lib/presentation/features/therapists/screens/communication_therapist_marketplace_screen.dart
+++ b/lib/presentation/features/therapists/screens/communication_therapist_marketplace_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 
 import '../controllers/communication_therapist_controller.dart';
 import '../models/communication_therapist.dart';
+import '../../../shared/widgets/xpressatec_header.dart';
 
 class CommunicationTherapistMarketplaceScreen extends GetView<CommunicationTherapistController> {
   const CommunicationTherapistMarketplaceScreen({super.key});
@@ -20,14 +20,10 @@ class CommunicationTherapistMarketplaceScreen extends GetView<CommunicationThera
     return Scaffold(
       backgroundColor: const Color(0xFFE3F2FD),
       appBar: AppBar(
-        centerTitle: true,
-        backgroundColor: Colors.white,
+        automaticallyImplyLeading: true,
         elevation: 0,
-        title: SvgPicture.asset(
-          'assets/images/imagen.svg',
-          height: 32,
-          semanticsLabel: 'Xpressatec',
-        ),
+        backgroundColor: Colors.transparent,
+        foregroundColor: colorScheme.onSurface,
       ),
       body: SafeArea(
         child: Padding(
@@ -35,6 +31,8 @@ class CommunicationTherapistMarketplaceScreen extends GetView<CommunicationThera
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              const XpressatecHeader(),
+              const SizedBox(height: 16),
               Text(
                 'Terapeutas en comunicación',
                 style: theme.textTheme.headlineSmall?.copyWith(

--- a/lib/presentation/shared/widgets/xpressatec_header.dart
+++ b/lib/presentation/shared/widgets/xpressatec_header.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class XpressatecHeader extends StatelessWidget {
+  const XpressatecHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8.0),
+      child: Center(
+        child: SvgPicture.asset(
+          'assets/images/imagen.svg',
+          height: 200,
+          fit: BoxFit.contain,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add an `XpressatecHeader` widget that renders the shared SVG branding at a fixed height
- update non-chat feature screens to include the header and move textual titles from app bars into the body content
- align reusable layouts and navigation scaffolds with the new header pattern for consistency

## Testing
- not run (Flutter CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117e4319e0832f8ecf92093aea9099)