### PR TITLE
Refactor home scaffold header layout

### DIFF
--- a/lib/core/config/routes.dart
+++ b/lib/core/config/routes.dart
@@ -62,7 +62,7 @@ class AppRoutes {
     ),
     GetPage(
       name: Routes.home,
-      page: () => const HomeScreen(),
+      page: () => HomeScreen(),
       binding: HomeBinding(),
     ),
     GetPage(

--- a/lib/presentation/features/home/screens/home_screen.dart
+++ b/lib/presentation/features/home/screens/home_screen.dart
@@ -6,14 +6,17 @@ import 'package:xpressatec/presentation/features/home/widgets/bottom_nav_bar.dar
 import 'package:xpressatec/presentation/features/home/widgets/custom_drawer.dart';
 import 'package:xpressatec/presentation/features/statistics/screens/statistics_screen.dart';
 import 'package:xpressatec/presentation/features/teacch_board/screens/teacch_board_screen.dart';
+import 'package:xpressatec/presentation/features/teacch_board/widgets/generate_phrase_fab.dart';
+import 'package:xpressatec/presentation/shared/widgets/xpressatec_header_appbar.dart';
 
 class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+  HomeScreen({super.key});
+
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
   @override
   Widget build(BuildContext context) {
     final NavigationController navController = Get.find();
-    final theme = Theme.of(context);
 
     return Obx(() {
       final section = navController.currentSection;
@@ -32,17 +35,24 @@ class HomeScreen extends StatelessWidget {
       }
 
       return Scaffold(
+        key: _scaffoldKey,
+        backgroundColor: Colors.white,
         appBar: section == NavigationSection.chat
             ? null
-            : AppBar(
-                automaticallyImplyLeading: true,
-                elevation: 0,
-                backgroundColor: Colors.transparent,
-                foregroundColor: theme.colorScheme.onSurface,
+            : XpressatecHeaderAppBar(
+                showMenu: true,
+                onMenuTap: () => _scaffoldKey.currentState?.openDrawer(),
               ),
         drawer: const CustomDrawer(),
         body: body,
         bottomNavigationBar: const BottomNavBar(),
+        floatingActionButton: section == NavigationSection.teacch
+            ? const TeacchGeneratePhraseFab()
+            : null,
+        floatingActionButtonLocation:
+            section == NavigationSection.teacch
+                ? FloatingActionButtonLocation.centerFloat
+                : null,
       );
     });
   }

--- a/lib/presentation/features/statistics/screens/statistics_screen.dart
+++ b/lib/presentation/features/statistics/screens/statistics_screen.dart
@@ -7,7 +7,6 @@ import 'package:xpressatec/presentation/features/statistics/widgets/recent_phras
 import 'package:xpressatec/presentation/features/statistics/widgets/time_range_selector.dart';
 import 'package:xpressatec/presentation/features/statistics/widgets/timeline_chart_widget.dart';
 import 'package:xpressatec/presentation/features/statistics/widgets/top_words_chart_widget.dart';
-import 'package:xpressatec/presentation/shared/widgets/xpressatec_header_appbar.dart';
 
 class StatisticsScreen extends StatelessWidget {
   const StatisticsScreen({Key? key}) : super(key: key);
@@ -46,127 +45,127 @@ class StatisticsScreen extends StatelessWidget {
       );
 
       if (enableRefresh) {
-        return RefreshIndicator(
+        final refreshable = RefreshIndicator(
           onRefresh: () => controller.refresh(),
           child: scrollView,
         );
+
+        return SafeArea(
+          bottom: false,
+          child: refreshable,
+        );
       }
 
-      return scrollView;
+      return SafeArea(
+        bottom: false,
+        child: scrollView,
+      );
     }
 
-    return Scaffold(
-      backgroundColor: Colors.white,
-      appBar: const XpressatecHeaderAppBar(showBack: true),
-      body: SafeArea(
-        child: Obx(() {
-          if (controller.isLoading.value) {
-            return buildContent(
-              children: const [
-                SizedBox(height: 24),
-                SizedBox(
-                  width: double.infinity,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      CircularProgressIndicator(),
-                      SizedBox(height: 16),
-                      Text('Cargando estadísticas...'),
-                    ],
-                  ),
-                ),
-              ],
-            );
-          }
-
-          if (controller.errorMessage.isNotEmpty) {
-            return buildContent(
-              children: [
-                const SizedBox(height: 24),
-                SizedBox(
-                  width: double.infinity,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const Icon(Icons.error_outline,
-                          size: 64, color: Colors.red),
-                      const SizedBox(height: 16),
-                      Text(
-                        'Error: ${controller.errorMessage.value}',
-                        textAlign: TextAlign.center,
-                      ),
-                      const SizedBox(height: 16),
-                      ElevatedButton(
-                        onPressed: () => controller.refresh(),
-                        child: const Text('Reintentar'),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            );
-          }
-
-          if (controller.allPhrases.isEmpty) {
-            return buildContent(
-              enableRefresh: true,
-              children: [
-                const SizedBox(height: 24),
-                SizedBox(
-                  width: double.infinity,
-                  child: Column(
-                    children: [
-                      Icon(Icons.analytics_outlined,
-                          size: 64, color: Colors.grey[400]),
-                      const SizedBox(height: 16),
-                      Text(
-                        'Aún no hay frases guardadas',
-                        style:
-                            TextStyle(fontSize: 18, color: Colors.grey[600]),
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        'Genera y guarda frases para ver tus estadísticas',
-                        style: TextStyle(color: Colors.grey[500]),
-                        textAlign: TextAlign.center,
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            );
-          }
-
-          return buildContent(
-            enableRefresh: true,
-            children: [
-              TimeRangeSelector(
-                selectedRange: controller.selectedTimeRange.value,
-                onChanged: (range) => controller.changeTimeRange(range),
+    return Obx(() {
+      if (controller.isLoading.value) {
+        return buildContent(
+          children: const [
+            SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  CircularProgressIndicator(),
+                  SizedBox(height: 16),
+                  Text('Cargando estadísticas...'),
+                ],
               ),
-              const SizedBox(height: 16),
-              OverviewCards(statistics: controller.statistics.value),
-              const SizedBox(height: 24),
-              _buildSectionTitle('Actividad'),
-              const SizedBox(height: 12),
-              TimelineChartWidget(statistics: controller.statistics.value),
-              const SizedBox(height: 24),
-              _buildSectionTitle('Palabras Más Usadas'),
-              const SizedBox(height: 12),
-              TopWordsChartWidget(statistics: controller.statistics.value),
-              const SizedBox(height: 24),
-              _buildSectionTitle('Uso por Categoría'),
-              const SizedBox(height: 12),
-              CategoryPieChartWidget(statistics: controller.statistics.value),
-              const SizedBox(height: 24),
-              _buildSectionTitle('Frases Recientes'),
-              const SizedBox(height: 12),
-              RecentPhrasesList(phrases: controller.filteredPhrases),
-            ],
-          );
-        }),
-      ),
-    );
+            ),
+          ],
+        );
+      }
+
+      if (controller.errorMessage.isNotEmpty) {
+        return buildContent(
+          children: [
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.error_outline, size: 64, color: Colors.red),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Error: ${controller.errorMessage.value}',
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => controller.refresh(),
+                    child: const Text('Reintentar'),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      }
+
+      if (controller.allPhrases.isEmpty) {
+        return buildContent(
+          enableRefresh: true,
+          children: [
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: Column(
+                children: [
+                  Icon(Icons.analytics_outlined,
+                      size: 64, color: Colors.grey[400]),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Aún no hay frases guardadas',
+                    style: TextStyle(fontSize: 18, color: Colors.grey[600]),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Genera y guarda frases para ver tus estadísticas',
+                    style: TextStyle(color: Colors.grey[500]),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      }
+
+      return buildContent(
+        enableRefresh: true,
+        children: [
+          TimeRangeSelector(
+            selectedRange: controller.selectedTimeRange.value,
+            onChanged: (range) => controller.changeTimeRange(range),
+          ),
+          const SizedBox(height: 16),
+          OverviewCards(statistics: controller.statistics.value),
+          const SizedBox(height: 24),
+          _buildSectionTitle('Actividad'),
+          const SizedBox(height: 12),
+          TimelineChartWidget(statistics: controller.statistics.value),
+          const SizedBox(height: 24),
+          _buildSectionTitle('Palabras Más Usadas'),
+          const SizedBox(height: 12),
+          TopWordsChartWidget(statistics: controller.statistics.value),
+          const SizedBox(height: 24),
+          _buildSectionTitle('Uso por Categoría'),
+          const SizedBox(height: 12),
+          CategoryPieChartWidget(statistics: controller.statistics.value),
+          const SizedBox(height: 24),
+          _buildSectionTitle('Frases Recientes'),
+          const SizedBox(height: 12),
+          RecentPhrasesList(phrases: controller.filteredPhrases),
+        ],
+      );
+    });
   }
 
   Widget _buildSectionTitle(String title) {

--- a/lib/presentation/features/teacch_board/screens/teacch_board_screen.dart
+++ b/lib/presentation/features/teacch_board/screens/teacch_board_screen.dart
@@ -4,8 +4,6 @@ import 'package:xpressatec/core/constants/app_constants.dart';
 
 import 'package:xpressatec/presentation/features/teacch_board/controllers/teacch_controller.dart';
 import 'package:xpressatec/presentation/features/teacch_board/widgets/category_detail_sheet.dart';
-import 'package:xpressatec/presentation/shared/widgets/xpressatec_header_appbar.dart';
-import '../controllers/tts_controller.dart';
 import '../widgets/board_grid.dart';
 import '../widgets/selected_items_bar.dart';
 import '../widgets/teacch_card_widget.dart';
@@ -16,12 +14,11 @@ class TeacchBoardScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final controller = Get.find<TeacchController>();
-    final ttsController = Get.find<TtsController>();
 
     // ✅ Use AppConstants instead of direct variables
     final List<TeacchCardWidget> categoryCards = List.generate(
       AppConstants.mainCategories.length,
-          (index) {
+      (index) {
         final category = AppConstants.mainCategories[index];
         final icon = AppConstants.categoryIcons[index];
 
@@ -32,7 +29,6 @@ class TeacchBoardScreen extends StatelessWidget {
           showLabel: true,
           onTap: () async {
             await controller.loadCategoryDetails(category);
-           // ttsController.tellPhrase11labs(category.name);
 
             Get.bottomSheet(
               FractionallySizedBox(
@@ -47,51 +43,21 @@ class TeacchBoardScreen extends StatelessWidget {
       },
     );
 
-    return Scaffold(
-      backgroundColor: Colors.white,
-      appBar: const XpressatecHeaderAppBar(),
-      body: SafeArea(
-        child: Column(
-          children: [
-            const SizedBox(height: 16),
-            // ✨ Scrollable selected items bar (only visible when items are selected)
-            SelectedItemsBar(),
-            const SizedBox(height: 16),
-            Expanded(
-              child: BoardGrid(
-                cards: categoryCards,
-              ),
+    return SafeArea(
+      bottom: false,
+      child: Column(
+        children: [
+          const SizedBox(height: 16),
+          // ✨ Scrollable selected items bar (only visible when items are selected)
+          SelectedItemsBar(),
+          const SizedBox(height: 16),
+          Expanded(
+            child: BoardGrid(
+              cards: categoryCards,
             ),
-          ],
-        ),
+          ),
+        ],
       ),
-
-      // ✨ NEW: Floating Action Button (visible only with 2+ items)
-      floatingActionButton: Obx(() {
-        // Only show FAB if 2 or more items are selected
-        if (controller.selectedItems.length >= 2) {
-          return FloatingActionButton.extended(
-            onPressed: () {
-              // Generate and show phrase dialog
-              controller.generateAndShowPhrase();
-            },
-            backgroundColor: Colors.green,
-            icon: const Icon(Icons.auto_awesome, color: Colors.white),
-            label: const Text(
-              'Generar Frase',
-              style: TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.bold,
-                fontSize: 16,
-              ),
-            ),
-          );
-        } else {
-          // Return empty SizedBox when less than 2 items
-          return const SizedBox.shrink();
-        }
-      }),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
     );
   }
 }

--- a/lib/presentation/features/teacch_board/widgets/generate_phrase_fab.dart
+++ b/lib/presentation/features/teacch_board/widgets/generate_phrase_fab.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:xpressatec/presentation/features/teacch_board/controllers/teacch_controller.dart';
+
+class TeacchGeneratePhraseFab extends StatelessWidget {
+  const TeacchGeneratePhraseFab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<TeacchController>();
+
+    return Obx(() {
+      if (controller.selectedItems.length >= 2) {
+        return FloatingActionButton.extended(
+          onPressed: controller.generateAndShowPhrase,
+          backgroundColor: Colors.green,
+          icon: const Icon(Icons.auto_awesome, color: Colors.white),
+          label: const Text(
+            'Generar Frase',
+            style: TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+              fontSize: 16,
+            ),
+          ),
+        );
+      }
+
+      return const SizedBox.shrink();
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- centralize the Xpressatec header inside the home scaffold and expose the TEACCH FAB from the parent
- simplify tab screens to return only their bodies, removing nested scaffolds and duplicated headers
- add a reusable FAB widget for generating phrases and adjust routing to use the updated home screen constructor

## Testing
- Not run (flutter not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69118c6d5dd0832fb01754536cf89b80)