### PR TITLE
Adjust global header AppBar layout

### DIFF
--- a/lib/presentation/shared/widgets/xpressatec_header_appbar.dart
+++ b/lib/presentation/shared/widgets/xpressatec_header_appbar.dart
@@ -5,55 +5,54 @@ class XpressatecHeaderAppBar extends StatelessWidget
     implements PreferredSizeWidget {
   const XpressatecHeaderAppBar({
     super.key,
-    this.showBack = false,
     this.showMenu = false,
     this.onMenuTap,
+    this.showBack = false,
   });
 
-  final bool showBack;
   final bool showMenu;
   final VoidCallback? onMenuTap;
+  final bool showBack;
 
   @override
-  Size get preferredSize => const Size.fromHeight(200);
+  Size get preferredSize => const Size.fromHeight(80);
 
   @override
   Widget build(BuildContext context) {
-    final color = Theme.of(context).colorScheme.onSurface;
+    final theme = Theme.of(context);
+    final color = theme.colorScheme.onSurface;
 
     return AppBar(
-      automaticallyImplyLeading: false,
+      backgroundColor: theme.scaffoldBackgroundColor,
       elevation: 0,
-      backgroundColor: Colors.transparent,
+      automaticallyImplyLeading: false,
+      centerTitle: true,
       foregroundColor: color,
-      flexibleSpace: SafeArea(
-        child: Stack(
-          children: [
-            Center(
-              child: SvgPicture.asset(
-                'assets/images/imagen.svg',
-                height: 200,
-                fit: BoxFit.contain,
-              ),
-            ),
-            if (showBack)
-              Align(
-                alignment: Alignment.topLeft,
-                child: IconButton(
-                  icon: Icon(Icons.arrow_back, color: color),
-                  onPressed: () => Navigator.of(context).maybePop(),
-                ),
-              ),
-            if (showMenu)
-              Align(
-                alignment: Alignment.topRight,
-                child: IconButton(
-                  icon: Icon(Icons.menu, color: color),
-                  onPressed: onMenuTap,
-                ),
-              ),
-          ],
-        ),
+      toolbarHeight: preferredSize.height,
+      leading: showBack
+          ? IconButton(
+              icon: Icon(Icons.arrow_back, color: color),
+              onPressed: () => Navigator.of(context).maybePop(),
+            )
+          : (showMenu
+              ? Builder(
+                  builder: (context) {
+                    return IconButton(
+                      icon: Icon(Icons.menu, color: color),
+                      onPressed: onMenuTap ?? () {
+                        final scaffoldState = Scaffold.maybeOf(context);
+                        if (scaffoldState != null && scaffoldState.hasDrawer) {
+                          scaffoldState.openDrawer();
+                        }
+                      },
+                    );
+                  },
+                )
+              : null),
+      title: SvgPicture.asset(
+        'assets/images/imagen.svg',
+        height: 200,
+        fit: BoxFit.contain,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- update the shared Xpressatec header AppBar to use a standard-height toolbar with centered logo
- align the optional menu/back controls on the leading edge and default menu tap to opening the drawer when available
- scale the logo SVG with BoxFit.contain so it fits cleanly within the reduced AppBar height

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69118fb4df54832f96d4fc72c27cac63)