### PR TITLE
Ensure therapist registration collects birth date and cedula

### DIFF
--- a/lib/presentation/features/auth/screens/register_screen.dart
+++ b/lib/presentation/features/auth/screens/register_screen.dart
@@ -294,101 +294,103 @@ class RegisterScreen extends GetView<AuthController> {
 
             // Conditional Fields based on Role
             Obx(() {
-              // Fecha de Nacimiento for Paciente and Tutor
-              if (controller.selectedRole.value == 'Paciente' ||
-                  controller.selectedRole.value == 'Tutor') {
-                return Column(
-                  children: [
-                    TextFormField(
-                      controller: fechaNacimientoController,
-                      readOnly: true,
-                      decoration: InputDecoration(
-                        labelText: 'Fecha de nacimiento',
-                        hintText: 'dd/mm/aaaa',
-                        prefixIcon: const Icon(Icons.calendar_today_outlined),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        enabledBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(color: Colors.grey.shade300),
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: const BorderSide(color: Colors.blue, width: 2),
-                        ),
-                      ),
-                      onTap: () async {
-                        final DateTime? picked = await showDatePicker(
-                          context: context,
-                          initialDate: DateTime(2000),
-                          firstDate: DateTime(1920),
-                          lastDate: DateTime.now(),
-                          builder: (context, child) {
-                            return Theme(
-                              data: Theme.of(context).copyWith(
-                                colorScheme: ColorScheme.light(
-                                  primary: Colors.blue.shade700,
-                                ),
-                              ),
-                              child: child!,
+              final role = controller.selectedRole.value;
+              final requiresBirthDate =
+                  role == 'Paciente' || role == 'Tutor' || role == 'Terapeuta';
+              final showCedula = role == 'Terapeuta';
+
+              return Column(
+                children: [
+                  if (requiresBirthDate)
+                    Column(
+                      children: [
+                        TextFormField(
+                          controller: fechaNacimientoController,
+                          readOnly: true,
+                          decoration: InputDecoration(
+                            labelText: 'Fecha de nacimiento',
+                            hintText: 'dd/mm/aaaa',
+                            prefixIcon: const Icon(Icons.calendar_today_outlined),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            enabledBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: BorderSide(color: Colors.grey.shade300),
+                            ),
+                            focusedBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: const BorderSide(color: Colors.blue, width: 2),
+                            ),
+                          ),
+                          onTap: () async {
+                            final DateTime? picked = await showDatePicker(
+                              context: context,
+                              initialDate: DateTime(2000),
+                              firstDate: DateTime(1920),
+                              lastDate: DateTime.now(),
+                              builder: (context, child) {
+                                return Theme(
+                                  data: Theme.of(context).copyWith(
+                                    colorScheme: ColorScheme.light(
+                                      primary: Colors.blue.shade700,
+                                    ),
+                                  ),
+                                  child: child!,
+                                );
+                              },
                             );
+                            if (picked != null) {
+                              onDateSelected(picked);
+                              fechaNacimientoController.text =
+                                  '${picked.day.toString().padLeft(2, '0')}/${picked.month.toString().padLeft(2, '0')}/${picked.year}';
+                            }
                           },
-                        );
-                        if (picked != null) {
-                          onDateSelected(picked);
-                          fechaNacimientoController.text =
-                          '${picked.day.toString().padLeft(2, '0')}/${picked.month.toString().padLeft(2, '0')}/${picked.year}';
-                        }
-                      },
-                      validator: (value) {
-                        if (value == null || value.isEmpty) {
-                          return 'Por favor selecciona tu fecha de nacimiento';
-                        }
-                        return null;
-                      },
+                          validator: (value) {
+                            if (requiresBirthDate &&
+                                (value == null || value.isEmpty)) {
+                              return 'Por favor selecciona tu fecha de nacimiento';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 16),
+                      ],
                     ),
-                    const SizedBox(height: 16),
-                  ],
-                );
-              }
-
-              // Cédula for Terapeuta
-              if (controller.selectedRole.value == 'Terapeuta') {
-                return Column(
-                  children: [
-                    TextFormField(
-                      controller: cedulaController,
-                      keyboardType: TextInputType.text,
-                      decoration: InputDecoration(
-                        labelText: 'Cédula profesional',
-                        hintText: '1234567',
-                        prefixIcon: const Icon(Icons.badge_outlined),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
+                  if (showCedula)
+                    Column(
+                      children: [
+                        TextFormField(
+                          controller: cedulaController,
+                          keyboardType: TextInputType.text,
+                          decoration: InputDecoration(
+                            labelText: 'Cédula profesional',
+                            hintText: '1234567',
+                            prefixIcon: const Icon(Icons.badge_outlined),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            enabledBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: BorderSide(color: Colors.grey.shade300),
+                            ),
+                            focusedBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: const BorderSide(color: Colors.blue, width: 2),
+                            ),
+                          ),
+                          validator: (value) {
+                            if (showCedula && (value == null || value.isEmpty)) {
+                              return 'Por favor ingresa tu cédula profesional';
+                            }
+                            return null;
+                          },
                         ),
-                        enabledBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(color: Colors.grey.shade300),
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: const BorderSide(color: Colors.blue, width: 2),
-                        ),
-                      ),
-                      validator: (value) {
-                        if (value == null || value.isEmpty) {
-                          return 'Por favor ingresa tu cédula profesional';
-                        }
-                        return null;
-                      },
+                        const SizedBox(height: 16),
+                      ],
                     ),
-                    const SizedBox(height: 16),
-                  ],
-                );
-              }
-
-              return const SizedBox.shrink();
+                ],
+              );
             }),
 
             const SizedBox(height: 8),
@@ -417,13 +419,20 @@ class RegisterScreen extends GetView<AuthController> {
                     }
                   }
 
+                  final selectedRole = controller.selectedRole.value;
+                  final requiresBirthDate = selectedRole == 'Paciente' ||
+                      selectedRole == 'Tutor' ||
+                      selectedRole == 'Terapeuta';
+
                   controller.register(
                     nombre: nombreController.text.trim(),
                     email: emailController.text.trim(),
                     password: passwordController.text,
-                    rol: controller.selectedRole.value,
-                    fechaNacimiento: formattedDate,
-                    cedula: cedulaController.text.trim().isNotEmpty
+                    rol: selectedRole,
+                    fechaNacimiento:
+                        requiresBirthDate ? formattedDate : null,
+                    cedula: selectedRole == 'Terapeuta' &&
+                            cedulaController.text.trim().isNotEmpty
                         ? cedulaController.text.trim()
                         : null,
                   );


### PR DESCRIPTION
## Summary
- show the birth date field for all registration roles and add the cedula field only for therapists
- update therapist validation so birth date remains required and cedula is validated only when visible
- send the cedula value to the backend exclusively when the therapist role is selected

## Testing
- Not run (environment not configured for Flutter tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691193caa564832f9f03a5308e850956)