### PR TITLE
Add cropping and reactive refresh to custom pictograms

### DIFF
--- a/lib/presentation/features/customization/controllers/customization_controller.dart
+++ b/lib/presentation/features/customization/controllers/customization_controller.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:path/path.dart' as p;
 
@@ -20,12 +21,15 @@ class CustomizationController extends GetxController {
     required this.localAssetStorage,
     required this.localStorage,
     ImagePicker? imagePicker,
-  }) : _imagePicker = imagePicker ?? ImagePicker();
+    ImageCropper? imageCropper,
+  }) : _imagePicker = imagePicker ?? ImagePicker(),
+        _imageCropper = imageCropper ?? ImageCropper();
 
   final MediaApiDatasource mediaApiDatasource;
   final LocalAssetStorage localAssetStorage;
   final LocalStorage localStorage;
   final ImagePicker _imagePicker;
+  final ImageCropper _imageCropper;
 
   final RxBool isDownloading = false.obs;
   final RxInt downloadedCount = 0.obs;
@@ -39,7 +43,11 @@ class CustomizationController extends GetxController {
 
   final Map<String, ImageProvider> _providerCache = {};
   final Set<String> _localCache = <String>{};
-  final Map<String, List<CustomPictogram>> _customPictograms = {};
+  final RxMap<String, List<CustomPictogram>> _customPictograms =
+      <String, List<CustomPictogram>>{}.obs;
+
+  late final List<String> _defaultDestinationFolders =
+      _buildDefaultDestinationFolders();
 
   bool _initialized = false;
 
@@ -47,7 +55,7 @@ class CustomizationController extends GetxController {
     if (_initialized) return;
     _initialized = true;
 
-    await _loadCustomPictograms();
+    await loadPictogramsFromStorage();
 
     final bool alreadyDownloaded = localStorage.getBool(_downloadedKey) ?? false;
     if (alreadyDownloaded) {
@@ -72,6 +80,18 @@ class CustomizationController extends GetxController {
 
   bool get hasDownloadedPictograms =>
       localStorage.getBool(_downloadedKey) ?? false;
+
+  List<String> get availableDestinationFolders {
+    final Set<String> folders = {..._defaultDestinationFolders};
+    folders.addAll(
+      _customPictograms.keys
+          .map(_stripImagesPrefix)
+          .map(_ensureTrailingSlash),
+    );
+    final List<String> sorted = folders.toList()
+      ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+    return List<String>.unmodifiable(sorted);
+  }
 
   Future<void> refreshDownloadStatus() async {
     final downloaded = hasDownloadedPictograms;
@@ -183,20 +203,62 @@ class CustomizationController extends GetxController {
     }
   }
 
-  Future<void> addCustomPictogram(String parentPath) async {
+  Future<void> addCustomPictogramToFolder(String parentPath) async {
     try {
-      final XFile? file = await _imagePicker.pickImage(source: ImageSource.gallery);
+      final XFile? file =
+          await _imagePicker.pickImage(source: ImageSource.gallery);
       if (file == null) {
         return;
       }
 
+      final List<PlatformUiSettings> cropperSettings = [];
+      if (GetPlatform.isAndroid) {
+        cropperSettings.add(
+          const AndroidUiSettings(
+            toolbarTitle: 'Ajustar pictograma',
+            lockAspectRatio: true,
+            hideBottomControls: true,
+          ),
+        );
+      }
+      if (GetPlatform.isIOS) {
+        cropperSettings.add(
+          const IOSUiSettings(
+            title: 'Ajustar pictograma',
+            aspectRatioLockEnabled: true,
+          ),
+        );
+      }
+      if (GetPlatform.isWeb && Get.context != null) {
+        cropperSettings.add(
+          WebUiSettings(
+            context: Get.context!,
+            presentStyle: CropperPresentStyle.dialog,
+            enableResize: true,
+            lockAspectRatio: true,
+          ),
+        );
+      }
+
+      final CroppedFile? cropped = await _imageCropper.cropImage(
+        sourcePath: file.path,
+        aspectRatio: const CropAspectRatio(ratioX: 1, ratioY: 1),
+        compressFormat: ImageCompressFormat.png,
+        uiSettings: cropperSettings,
+      );
+
+      if (cropped == null) {
+        return;
+      }
+
       final String? suggestedName = _extractBaseName(file);
-      final String? providedName = await _promptForCustomName(initialValue: suggestedName);
+      final String? providedName =
+          await _promptForCustomName(initialValue: suggestedName);
       if (providedName == null || providedName.trim().isEmpty) {
         return;
       }
 
-      final String normalizedParent = MediaPathMapper.normalize(parentPath);
+      final String folderKey = _normalizeFolderKey(parentPath);
       final String sanitizedFileName = _sanitizeFileName(providedName);
       if (sanitizedFileName.isEmpty) {
         Get.snackbar(
@@ -207,40 +269,46 @@ class CustomizationController extends GetxController {
         return;
       }
 
-      final String extension = _detectExtension(file);
-      final String joinedPath = _joinPaths(normalizedParent, '$sanitizedFileName$extension');
-      final String normalizedPath = MediaPathMapper.normalize(joinedPath);
+      final String extension =
+          _detectExtensionFromPath(cropped.path.isNotEmpty ? cropped.path : file.path);
+      final String relativePath = '$folderKey$sanitizedFileName$extension';
+      final String normalizedRelativePath =
+          MediaPathMapper.normalize(relativePath);
 
-      if (_customPictogramExists(normalizedPath)) {
+      final CustomPictogram? existing =
+          _findCustomPictogramByRelativePath(relativePath);
+      final bool reservedPath =
+          _isReservedPictogramPath(relativePath) && existing == null;
+
+      if (reservedPath) {
         Get.snackbar(
           'Pictograma existente',
-          'Ya existe un pictograma con ese nombre en esta categoría.',
+          'Ya existe un pictograma oficial con ese nombre en esta categoría.',
           snackPosition: SnackPosition.BOTTOM,
         );
         return;
       }
 
-      final bytes = await file.readAsBytes();
-      await localAssetStorage.saveImage(normalizedPath, bytes);
+      final bytes = await cropped.readAsBytes();
+      await localAssetStorage.saveImage(normalizedRelativePath, bytes);
 
       final pictogram = CustomPictogram(
-        id: _generateId(),
+        id: existing?.id ?? _generateId(),
         name: providedName.trim(),
-        relativePath: normalizedPath,
-        parentPath: normalizedParent,
+        relativePath: relativePath,
+        parentPath: folderKey,
+        createdAt: existing?.createdAt,
       );
 
       _addCustomPictogramToCache(pictogram);
       await _persistCustomPictograms();
+      await loadPictogramsFromStorage();
 
-      _localCache.add(MediaPathMapper.normalize(normalizedPath));
-      _providerCache.remove(MediaPathMapper.normalize(normalizedPath));
-
-      treeRefreshToken.value++;
-      update();
+      _localCache.add(normalizedRelativePath);
+      _providerCache.remove(normalizedRelativePath);
 
       Get.snackbar(
-        'Pictograma agregado',
+        existing == null ? 'Pictograma agregado' : 'Pictograma actualizado',
         'Disponible solo en este dispositivo.',
         snackPosition: SnackPosition.BOTTOM,
       );
@@ -251,6 +319,10 @@ class CustomizationController extends GetxController {
         snackPosition: SnackPosition.BOTTOM,
       );
     }
+  }
+
+  Future<void> addCustomPictogram(String parentPath) async {
+    await addCustomPictogramToFolder(parentPath);
   }
 
   Future<ImageProvider> getImageProvider(String relativePath) async {
@@ -281,7 +353,7 @@ class CustomizationController extends GetxController {
   }
 
   List<CustomPictogram> getCustomPictogramsForParent(String parentPath) {
-    final normalized = MediaPathMapper.normalize(parentPath);
+    final normalized = _normalizeFolderKey(parentPath);
     final list = _customPictograms[normalized];
     if (list == null) {
       return const [];
@@ -297,27 +369,37 @@ class CustomizationController extends GetxController {
     }
   }
 
-  Future<void> _loadCustomPictograms() async {
+  Future<void> loadPictogramsFromStorage() async {
     final stored = await localStorage.getCustomPictograms();
-    _customPictograms.clear();
+    final Map<String, List<CustomPictogram>> grouped = {};
+    final Set<String> discoveredLocalPaths = {};
 
     for (final pictogram in stored) {
-      final normalizedParent = MediaPathMapper.normalize(pictogram.parentPath);
-      final normalizedPath = MediaPathMapper.normalize(pictogram.relativePath);
+      final folderKey = _normalizeFolderKey(pictogram.parentPath);
+      final relativePath = _normalizeRelativeFilePath(pictogram.relativePath);
       final normalized = pictogram.copyWith(
-        parentPath: normalizedParent,
-        relativePath: normalizedPath,
+        parentPath: folderKey,
+        relativePath: relativePath,
       );
 
-      final list = _customPictograms.putIfAbsent(normalizedParent, () => []);
+      final list = grouped.putIfAbsent(folderKey, () => <CustomPictogram>[]);
       list.add(normalized);
 
-      if (await localAssetStorage.exists(normalizedPath)) {
-        _localCache.add(normalizedPath);
+      if (await localAssetStorage.exists(relativePath)) {
+        discoveredLocalPaths.add(MediaPathMapper.normalize(relativePath));
       }
     }
 
+    _customPictograms.assignAll(grouped);
     _sortCustomLists();
+    _customPictograms.refresh();
+
+    if (discoveredLocalPaths.isNotEmpty) {
+      _localCache.addAll(discoveredLocalPaths);
+    }
+
+    treeRefreshToken.value++;
+    update();
   }
 
   Future<void> _persistCustomPictograms() async {
@@ -326,32 +408,36 @@ class CustomizationController extends GetxController {
   }
 
   void _addCustomPictogramToCache(CustomPictogram pictogram) {
-    final normalizedParent = MediaPathMapper.normalize(pictogram.parentPath);
-    final normalizedPath = MediaPathMapper.normalize(pictogram.relativePath);
+    final folderKey = _normalizeFolderKey(pictogram.parentPath);
+    final relativePath = _normalizeRelativeFilePath(pictogram.relativePath);
     final normalized = pictogram.copyWith(
-      parentPath: normalizedParent,
-      relativePath: normalizedPath,
+      parentPath: folderKey,
+      relativePath: relativePath,
     );
 
-    final list = _customPictograms.putIfAbsent(normalizedParent, () => []);
-    list.removeWhere(
-      (existing) => MediaPathMapper.normalize(existing.relativePath) == normalizedPath,
+    final List<CustomPictogram> current =
+        List<CustomPictogram>.from(_customPictograms[folderKey] ?? const []);
+    final int existingIndex = current.indexWhere(
+      (existing) =>
+          MediaPathMapper.normalize(existing.relativePath) ==
+              MediaPathMapper.normalize(relativePath) ||
+          existing.id == normalized.id,
     );
-    list.add(normalized);
 
-    _sortCustomLists();
-  }
-
-  bool _customPictogramExists(String relativePath) {
-    final normalized = MediaPathMapper.normalize(relativePath);
-    if (PictogramPaths.values.contains(normalized)) {
-      return true;
+    if (existingIndex >= 0) {
+      final previous = current[existingIndex];
+      current[existingIndex] =
+          normalized.copyWith(createdAt: previous.createdAt);
+    } else {
+      current.add(normalized);
     }
-    return _customPictograms.values.any(
-      (list) => list.any(
-        (p) => MediaPathMapper.normalize(p.relativePath) == normalized,
-      ),
+
+    current.sort(
+      (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
     );
+
+    _customPictograms[folderKey] = current;
+    _customPictograms.refresh();
   }
 
   Future<String?> _promptForCustomName({String? initialValue}) async {
@@ -399,11 +485,7 @@ class CustomizationController extends GetxController {
 
   String _detectExtension(XFile file) {
     final source = file.name.isNotEmpty ? file.name : file.path;
-    final ext = p.extension(source).toLowerCase();
-    if (ext.isEmpty) {
-      return '.png';
-    }
-    return ext;
+    return _detectExtensionFromPath(source);
   }
 
   String? _extractBaseName(XFile file) {
@@ -414,17 +496,121 @@ class CustomizationController extends GetxController {
     return p.basenameWithoutExtension(source);
   }
 
-  String _joinPaths(String parent, String child) {
-    final joined = p.join(parent, child);
-    return joined.replaceAll('\\', '/');
-  }
-
   String _generateId() => DateTime.now().microsecondsSinceEpoch.toString();
 
   void _sortCustomLists() {
-    for (final list in _customPictograms.values) {
-      list.sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    for (final entry in _customPictograms.entries.toList()) {
+      final List<CustomPictogram> sorted = List<CustomPictogram>.from(entry.value)
+        ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+      _customPictograms[entry.key] = sorted;
     }
+  }
+
+  String _detectExtensionFromPath(String sourcePath) {
+    final ext = p.extension(sourcePath).toLowerCase();
+    if (ext.isEmpty) {
+      return '.png';
+    }
+    return ext;
+  }
+
+  String _normalizeFolderKey(String parentPath) {
+    String sanitized = parentPath.trim().replaceAll('\\', '/');
+    if (sanitized.isEmpty) {
+      throw ArgumentError('parentPath cannot be empty');
+    }
+    if (sanitized.startsWith('/')) {
+      sanitized = sanitized.substring(1);
+    }
+    if (!sanitized.endsWith('/')) {
+      sanitized = '$sanitized/';
+    }
+    if (sanitized.startsWith('assets/')) {
+      sanitized = sanitized.substring('assets/'.length);
+    }
+    if (!sanitized.startsWith('images/')) {
+      sanitized = 'images/$sanitized';
+    }
+    return _ensureTrailingSlash(sanitized);
+  }
+
+  String _normalizeRelativeFilePath(String relativePath) {
+    final normalized = _stripAssetsPrefix(MediaPathMapper.normalize(relativePath));
+    return normalized.startsWith('/') ? normalized.substring(1) : normalized;
+  }
+
+  String _stripAssetsPrefix(String path) {
+    final normalized = MediaPathMapper.normalize(path);
+    if (normalized.startsWith('assets/')) {
+      return normalized.substring('assets/'.length);
+    }
+    return normalized;
+  }
+
+  String _stripImagesPrefix(String path) {
+    if (path.startsWith('images/')) {
+      return path.substring('images/'.length);
+    }
+    return path;
+  }
+
+  String _ensureTrailingSlash(String value) {
+    if (value.isEmpty) {
+      return value;
+    }
+    return value.endsWith('/') ? value : '$value/';
+  }
+
+  bool _isReservedPictogramPath(String relativePath) {
+    final normalized = MediaPathMapper.normalize(relativePath);
+    return PictogramPaths.values.any(
+      (path) => MediaPathMapper.normalize(path) == normalized,
+    );
+  }
+
+  CustomPictogram? _findCustomPictogramByRelativePath(String relativePath) {
+    final normalized = MediaPathMapper.normalize(relativePath);
+    for (final list in _customPictograms.values) {
+      for (final pictogram in list) {
+        if (MediaPathMapper.normalize(pictogram.relativePath) == normalized) {
+          return pictogram;
+        }
+      }
+    }
+    return null;
+  }
+
+  List<String> _buildDefaultDestinationFolders() {
+    final Set<String> folders = {};
+
+    for (final rawPath in PictogramPaths.values) {
+      final stripped = _stripAssetsPrefix(MediaPathMapper.normalize(rawPath));
+      final segments = stripped.split('/');
+      if (segments.length <= 1) {
+        continue;
+      }
+
+      String current = '';
+      for (int i = 0; i < segments.length - 1; i++) {
+        final segment = segments[i];
+        if (segment.isEmpty) {
+          continue;
+        }
+        current = current.isEmpty ? segment : '$current/$segment';
+        if (current == 'images') {
+          continue;
+        }
+        final folder = _stripImagesPrefix(current);
+        if (folder.isEmpty) {
+          continue;
+        }
+        folders.add(_ensureTrailingSlash(folder));
+      }
+    }
+
+    final List<String> sorted = folders.toList()
+      ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+    return List<String>.unmodifiable(sorted);
   }
 
   Future<bool> _askUserForDownload() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   intl: ^0.20.2
   mobile_scanner: ^5.1.1
   image_picker: ^1.1.2
+  image_cropper: ^7.0.4
   path: ^1.9.0
   path_provider: ^2.1.5
   shared_preferences: ^2.5.3


### PR DESCRIPTION
## Summary
- allow selecting valid custom destinations from the existing pictogram folder structure
- add image picking + cropping flow that writes the custom pictogram to the chosen folder and updates state reactively
- expose storage reloading helpers and refresh custom lists without requiring an app restart
- add the image_cropper dependency for the new trimming workflow

## Testing
- Not run (Flutter tooling is unavailable in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912b66032b4832fb3fb17505ae81735)