### PR TITLE
Update image_cropper dependency to v11

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   intl: ^0.20.2
   mobile_scanner: ^5.1.1
   image_picker: ^1.1.2
-  image_cropper: ^7.0.4
+  image_cropper: ^11.0.0
   path: ^1.9.0
   path_provider: ^2.1.5
   shared_preferences: ^2.5.3


### PR DESCRIPTION
## Summary
- bump image_cropper to ^11.0.0 so it is compatible with firebase_storage ^13.0.3

## Testing
- flutter pub get *(fails: flutter not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912ba1052ac832f88f71ca0a236d52a)