### PR TITLE
Implement tutor-patient linking flow from QR scan

### DIFF
--- a/lib/core/bindings/initial_binding.dart
+++ b/lib/core/bindings/initial_binding.dart
@@ -5,16 +5,20 @@ import '../../data/datasources/remote/api_auth_datasource.dart';
 import '../../data/datasources/remote/firebase_storage_datasource.dart';
 import '../../data/datasources/remote/firestore_datasource.dart'; // 🆕 ADD
 import '../../data/datasources/remote/media_api_datasource.dart';
+import '../../data/datasources/remote/tutor_link_api_datasource.dart';
 import '../../data/datasources/local/audio_package_manager.dart';
 import '../../data/repositories/auth_repository_impl.dart';
 import '../../data/repositories/phrase_repository_impl.dart'; // 🆕 ADD
+import '../../data/repositories/tutor_link_repository_impl.dart';
 import '../../domain/repositories/auth_repository.dart';
 import '../../domain/repositories/phrase_repository.dart'; // 🆕 ADD
+import '../../domain/repositories/tutor_link_repository.dart';
 import '../../domain/usecases/auth/get_current_user_usecase.dart';
 import '../../domain/usecases/auth/get_patient_qr_usecase.dart';
 import '../../domain/usecases/auth/login_usecase.dart';
 import '../../domain/usecases/auth/logout_usecase.dart';
 import '../../domain/usecases/auth/register_usecase.dart';
+import '../../domain/usecases/tutor/link_tutor_with_patient_usecase.dart';
 import '../../domain/usecases/phrase/save_phrase_usecase.dart'; // 🆕 ADD
 import '../../domain/usecases/phrase/get_user_phrases_usecase.dart'; // 🆕 ADD
 import '../../presentation/features/auth/controllers/auth_controller.dart';
@@ -44,6 +48,11 @@ class InitialBinding extends Bindings {
     // Firebase Auth datasource
     Get.put<ApiAuthDatasource>(
       ApiAuthDatasourceImpl(),
+      permanent: true,
+    );
+
+    Get.put<TutorLinkApiDatasource>(
+      TutorLinkApiDatasourceImpl(),
       permanent: true,
     );
 
@@ -94,6 +103,13 @@ class InitialBinding extends Bindings {
       permanent: true,
     );
 
+    Get.put<TutorLinkRepository>(
+      TutorLinkRepositoryImpl(
+        datasource: Get.find<TutorLinkApiDatasource>(),
+      ),
+      permanent: true,
+    );
+
     // Auth Use Cases
     Get.put<LoginUseCase>(
       LoginUseCase(repository: Get.find<AuthRepository>()),
@@ -117,6 +133,13 @@ class InitialBinding extends Bindings {
 
     Get.put<GetPatientQrUseCase>(
       GetPatientQrUseCase(repository: Get.find<AuthRepository>()),
+      permanent: true,
+    );
+
+    Get.put<LinkTutorWithPatientUseCase>(
+      LinkTutorWithPatientUseCase(
+        repository: Get.find<TutorLinkRepository>(),
+      ),
       permanent: true,
     );
 

--- a/lib/core/bindings/scan_qr_binding.dart
+++ b/lib/core/bindings/scan_qr_binding.dart
@@ -1,12 +1,17 @@
 import 'package:get/get.dart';
 
+import '../../domain/usecases/tutor/link_tutor_with_patient_usecase.dart';
+import '../../presentation/features/auth/controllers/auth_controller.dart';
 import '../../presentation/features/profile/controllers/scan_qr_controller.dart';
 
 class ScanQrBinding extends Bindings {
   @override
   void dependencies() {
     Get.lazyPut<ScanQrController>(
-      () => ScanQrController(),
+      () => ScanQrController(
+        linkTutorWithPatientUseCase: Get.find<LinkTutorWithPatientUseCase>(),
+        authController: Get.find<AuthController>(),
+      ),
     );
   }
 }

--- a/lib/data/datasources/remote/tutor_link_api_datasource.dart
+++ b/lib/data/datasources/remote/tutor_link_api_datasource.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../../models/link_tutor_response_model.dart';
+
+abstract class TutorLinkApiDatasource {
+  Future<LinkTutorResponseModel> linkTutorWithPatient({
+    required String patientUuid,
+    required String tutorEmail,
+  });
+}
+
+class TutorLinkApiDatasourceImpl implements TutorLinkApiDatasource {
+  TutorLinkApiDatasourceImpl({
+    http.Client? client,
+    String? baseUrl,
+  })  : _client = client ?? http.Client(),
+        _baseUrl = baseUrl ?? _defaultBaseUrl;
+
+  static const String _defaultBaseUrl = 'https://xpressatec.online';
+
+  final http.Client _client;
+  final String _baseUrl;
+
+  Map<String, String> get _headers => const {
+        'Content-Type': 'application/json',
+      };
+
+  Uri _buildUri(String path) => Uri.parse('$_baseUrl$path');
+
+  @override
+  Future<LinkTutorResponseModel> linkTutorWithPatient({
+    required String patientUuid,
+    required String tutorEmail,
+  }) async {
+    final response = await _client.post(
+      _buildUri('/link-tutor-patient'),
+      headers: _headers,
+      body: jsonEncode({
+        'patient_uuid': patientUuid,
+        'tutor_email': tutorEmail,
+      }),
+    );
+
+    final decoded = _decodeResponseBody(response);
+    final message = _extractMessage(decoded);
+
+    switch (response.statusCode) {
+      case 200:
+        return LinkTutorResponseModel(
+          success: true,
+          message:
+              message ?? 'Paciente vinculado correctamente.',
+        );
+      case 404:
+        return LinkTutorResponseModel(
+          success: false,
+          message:
+              message ?? 'Paciente o tutor no encontrado.',
+        );
+      case 409:
+        return LinkTutorResponseModel(
+          success: false,
+          message: message ?? 'Este paciente ya está vinculado a otro tutor.',
+        );
+      case 500:
+        return LinkTutorResponseModel(
+          success: false,
+          message: message ?? 'Ocurrió un error en el servidor.',
+        );
+      default:
+        return LinkTutorResponseModel(
+          success: false,
+          message:
+              message ?? 'No se pudo vincular al paciente. Inténtalo de nuevo.',
+        );
+    }
+  }
+
+  dynamic _decodeResponseBody(http.Response response) {
+    try {
+      if (response.bodyBytes.isEmpty) {
+        return null;
+      }
+      final decodedBody = utf8.decode(response.bodyBytes);
+      if (decodedBody.isEmpty) {
+        return null;
+      }
+      return jsonDecode(decodedBody);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  String? _extractMessage(dynamic decoded) {
+    if (decoded is Map<String, dynamic>) {
+      final Object? message = decoded['message'] ?? decoded['detail'];
+      return message?.toString();
+    }
+    if (decoded is String) {
+      return decoded;
+    }
+    return null;
+  }
+}

--- a/lib/data/models/link_tutor_response_model.dart
+++ b/lib/data/models/link_tutor_response_model.dart
@@ -1,0 +1,15 @@
+import '../../domain/entities/link_tutor_result.dart';
+
+class LinkTutorResponseModel {
+  const LinkTutorResponseModel({
+    required this.success,
+    required this.message,
+  });
+
+  final bool success;
+  final String message;
+
+  LinkTutorResult toEntity() {
+    return LinkTutorResult(success: success, message: message);
+  }
+}

--- a/lib/data/repositories/tutor_link_repository_impl.dart
+++ b/lib/data/repositories/tutor_link_repository_impl.dart
@@ -1,0 +1,24 @@
+import '../../domain/entities/link_tutor_result.dart';
+import '../../domain/repositories/tutor_link_repository.dart';
+import '../datasources/remote/tutor_link_api_datasource.dart';
+
+class TutorLinkRepositoryImpl implements TutorLinkRepository {
+  TutorLinkRepositoryImpl({
+    required this.datasource,
+  });
+
+  final TutorLinkApiDatasource datasource;
+
+  @override
+  Future<LinkTutorResult> linkTutorWithPatient({
+    required String patientUuid,
+    required String tutorEmail,
+  }) async {
+    final response = await datasource.linkTutorWithPatient(
+      patientUuid: patientUuid,
+      tutorEmail: tutorEmail,
+    );
+
+    return response.toEntity();
+  }
+}

--- a/lib/domain/entities/link_tutor_result.dart
+++ b/lib/domain/entities/link_tutor_result.dart
@@ -1,0 +1,9 @@
+class LinkTutorResult {
+  const LinkTutorResult({
+    required this.success,
+    required this.message,
+  });
+
+  final bool success;
+  final String message;
+}

--- a/lib/domain/repositories/tutor_link_repository.dart
+++ b/lib/domain/repositories/tutor_link_repository.dart
@@ -1,0 +1,8 @@
+import '../entities/link_tutor_result.dart';
+
+abstract class TutorLinkRepository {
+  Future<LinkTutorResult> linkTutorWithPatient({
+    required String patientUuid,
+    required String tutorEmail,
+  });
+}

--- a/lib/domain/usecases/tutor/link_tutor_with_patient_usecase.dart
+++ b/lib/domain/usecases/tutor/link_tutor_with_patient_usecase.dart
@@ -1,0 +1,20 @@
+import '../../entities/link_tutor_result.dart';
+import '../../repositories/tutor_link_repository.dart';
+
+class LinkTutorWithPatientUseCase {
+  const LinkTutorWithPatientUseCase({
+    required this.repository,
+  });
+
+  final TutorLinkRepository repository;
+
+  Future<LinkTutorResult> call({
+    required String patientUuid,
+    required String tutorEmail,
+  }) {
+    return repository.linkTutorWithPatient(
+      patientUuid: patientUuid,
+      tutorEmail: tutorEmail,
+    );
+  }
+}

--- a/lib/presentation/features/profile/controllers/scan_qr_controller.dart
+++ b/lib/presentation/features/profile/controllers/scan_qr_controller.dart
@@ -1,29 +1,117 @@
 import 'package:get/get.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
+import '../../../../domain/usecases/tutor/link_tutor_with_patient_usecase.dart';
+import '../../auth/controllers/auth_controller.dart';
+
 class ScanQrController extends GetxController {
+  ScanQrController({
+    required this.linkTutorWithPatientUseCase,
+    required this.authController,
+  });
+
+  final LinkTutorWithPatientUseCase linkTutorWithPatientUseCase;
+  final AuthController authController;
+
   final MobileScannerController scannerController = MobileScannerController();
 
   final RxBool isTorchOn = false.obs;
   final RxString statusMessage = 'Escanea un código QR para comenzar.'.obs;
   final RxBool hasError = false.obs;
   final RxnString scannedUuid = RxnString();
+  final RxBool isProcessing = false.obs;
 
-  void onDetect(BarcodeCapture capture) {
+  // ignore: avoid_void_async
+  void onDetect(BarcodeCapture capture) async {
+    if (isProcessing.value) return;
     if (capture.barcodes.isEmpty) return;
 
     final raw = capture.barcodes.first.rawValue;
     if (raw == null || raw.isEmpty) {
       hasError.value = true;
+      scannedUuid.value = null;
       statusMessage.value = 'El código escaneado no es válido.';
+      Get.snackbar(
+        'Código inválido',
+        statusMessage.value,
+        snackPosition: SnackPosition.BOTTOM,
+      );
       return;
     }
 
-    scannedUuid.value = raw;
-    hasError.value = false;
-    statusMessage.value = 'QR leído correctamente.';
-    // NO llamamos aún a ningún endpoint.
-    scannerController.stop();
+    isProcessing.value = true;
+    await scannerController.stop();
+
+    try {
+      if (!authController.isTutor) {
+        hasError.value = true;
+        scannedUuid.value = null;
+        statusMessage.value =
+            'Solo un tutor puede enlazar con un paciente.';
+        Get.snackbar(
+          'Acceso restringido',
+          statusMessage.value,
+          snackPosition: SnackPosition.BOTTOM,
+        );
+        return;
+      }
+
+      final tutorEmail = authController.currentUser.value?.email ??
+          authController.userEmail.value;
+      if (tutorEmail.isEmpty) {
+        hasError.value = true;
+        scannedUuid.value = null;
+        statusMessage.value =
+            'No se encontró el correo del tutor autenticado.';
+        Get.snackbar(
+          'Información incompleta',
+          statusMessage.value,
+          snackPosition: SnackPosition.BOTTOM,
+        );
+        return;
+      }
+
+      statusMessage.value = 'Vinculando paciente...';
+      hasError.value = false;
+      scannedUuid.value = null;
+
+      final result = await linkTutorWithPatientUseCase(
+        patientUuid: raw,
+        tutorEmail: tutorEmail,
+      );
+
+      if (result.success) {
+        hasError.value = false;
+        scannedUuid.value = raw;
+        statusMessage.value = result.message;
+        Get.snackbar(
+          '¡Éxito!',
+          statusMessage.value,
+          snackPosition: SnackPosition.BOTTOM,
+        );
+      } else {
+        hasError.value = true;
+        scannedUuid.value = null;
+        statusMessage.value = result.message;
+        Get.snackbar(
+          'No se pudo completar la vinculación',
+          statusMessage.value,
+          snackPosition: SnackPosition.BOTTOM,
+        );
+      }
+    } catch (e) {
+      hasError.value = true;
+      scannedUuid.value = null;
+      statusMessage.value =
+          'Error al enlazar con el paciente. Intenta de nuevo.';
+      Get.snackbar(
+        'Error',
+        statusMessage.value,
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } finally {
+      isProcessing.value = false;
+    }
   }
 
   Future<void> toggleTorch() async {


### PR DESCRIPTION
## Summary
- add data models, datasource, repository, and use case to call the /link-tutor-patient endpoint
- register the new dependencies in the initial bindings and inject them into the QR scan controller
- update the ScanQrController to validate tutor role, call the backend, and surface status messages based on the API response

## Testing
- `flutter analyze` *(fails: flutter not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69134d23d7c8832f859f1b2395f7bf84)