### PR TITLE
Integrate marketplace tutor profile endpoint

### DIFF
--- a/lib/data/datasources/marketplace_api_datasource.dart
+++ b/lib/data/datasources/marketplace_api_datasource.dart
@@ -18,9 +18,98 @@ class MarketplaceApiDatasource {
   final http.Client _client;
   static const String _base = 'https://xpressatec.online';
 
+  Future<Map<String, dynamic>> upsertTutorProfile({
+    required String email,
+    required String cedula,
+    String? especialidad,
+    String? tipoSector,
+    String? telefono,
+    String? celular,
+    String? correoAlternativo,
+    String? redSocial,
+    String? whatsapp,
+    String? token,
+  }) async {
+    final Uri uri = Uri.parse('$_base/marketplace/terapeuta/profile');
+
+    final Map<String, String> headers = <String, String>{
+      'Content-Type': 'application/json',
+      if (token != null && token.trim().isNotEmpty) 'Authorization': 'Bearer ${token.trim()}',
+    };
+
+    String? _normalize(String? value) {
+      if (value == null) {
+        return null;
+      }
+      final String trimmed = value.trim();
+      return trimmed.isEmpty ? null : trimmed;
+    }
+
+    final Map<String, String> contacto = <String, String>{};
+    void addContacto(String key, String? value) {
+      final String? normalized = _normalize(value);
+      if (normalized != null) {
+        contacto[key] = normalized;
+      }
+    }
+
+    addContacto('Telefono', telefono);
+    addContacto('Celular', celular);
+    addContacto('Correo', correoAlternativo);
+    addContacto('RedSocial', redSocial);
+    addContacto('WhatsApp', whatsapp);
+
+    final Map<String, dynamic> body = <String, dynamic>{
+      'email': email.trim(),
+      'cedula_profesional': cedula.trim(),
+      'especialidad': _normalize(especialidad),
+      'tipo_sector': _normalize(tipoSector) ?? 'PR',
+      'contacto': contacto.isEmpty ? null : contacto,
+    };
+
+    body.removeWhere((String key, dynamic value) => value == null);
+
+    final http.Response response = await _client.post(
+      uri,
+      headers: headers,
+      body: jsonEncode(body),
+    );
+
+    Map<String, dynamic>? decoded;
+    if (response.body.isNotEmpty) {
+      try {
+        final dynamic json = jsonDecode(response.body);
+        if (json is Map<String, dynamic>) {
+          decoded = json;
+        }
+      } catch (_) {
+        decoded = null;
+      }
+    }
+
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      final Map<String, dynamic> result = <String, dynamic>{
+        'success': true,
+        'message': decoded != null && decoded['message'] is String
+            ? decoded!['message'] as String
+            : 'Perfil de terapeuta actualizado correctamente para el marketplace.',
+        'data': decoded != null && decoded['data'] is Map<String, dynamic>
+            ? decoded!['data'] as Map<String, dynamic>
+            : decoded,
+      };
+      return result;
+    }
+
+    final String? message = decoded != null && decoded['message'] is String
+        ? decoded['message'] as String
+        : 'Error al comunicarse con el servicio (código ${response.statusCode}).';
+    throw MarketplaceApiException(response.statusCode, message);
+  }
+
+  @Deprecated('Usa upsertTutorProfile en su lugar')
   Future<void> upsertProfile(Map<String, dynamic> payload) async {
-    final uri = Uri.parse('$_base/marketplace/terapeuta/profile');
-    final res = await _client.post(
+    final Uri uri = Uri.parse('$_base/marketplace/terapeuta/profile');
+    final http.Response res = await _client.post(
       uri,
       headers: const {'Content-Type': 'application/json'},
       body: jsonEncode(payload),


### PR DESCRIPTION
## Summary
- add a dedicated `upsertTutorProfile` request in `MarketplaceApiDatasource` that prepares the JSON payload, forwards tokens when present, and surfaces backend errors
- update the marketplace `TutorProfileController` to validate the form, call the new datasource method, and show success or backend error messages via GetX snackbars

## Testing
- flutter analyze *(fails: Flutter SDK not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69167fdf50f0832f976865ebaa435e1c)