### PR TITLE
Integrate marketplace tutor profile endpoint

### DIFF
--- a/lib/data/datasources/marketplace_api_datasource.dart
+++ b/lib/data/datasources/marketplace_api_datasource.dart
@@ -13,16 +13,112 @@ class MarketplaceApiException implements Exception {
 }
 
 class MarketplaceApiDatasource {
-  MarketplaceApiDatasource({http.Client? client}) : _client = client ?? http.Client();
+  MarketplaceApiDatasource({http.Client? client})
+      : _client = client ?? http.Client();
 
   final http.Client _client;
-  static const String _base = 'https://xpressatec.online';
 
+  Future<Map<String, dynamic>> upsertTutorProfile({
+    required String email,
+    required String cedula,
+    String? especialidad,
+    required String tipoSector,
+    String? telefono,
+    String? celular,
+    String? correoAlternativo,
+    String? redSocial,
+    String? whatsapp,
+    String? token,
+  }) async {
+    final Uri url =
+        Uri.parse('https://xpressatec.online/marketplace/terapeuta/profile');
+
+    String? _normalize(String? value) {
+      if (value == null) {
+        return null;
+      }
+      final String trimmed = value.trim();
+      return trimmed.isEmpty ? null : trimmed;
+    }
+
+    final Map<String, String> headers = <String, String>{
+      'Content-Type': 'application/json; charset=utf-8',
+      if (token != null && token.trim().isNotEmpty)
+        'Authorization': 'Bearer ${token.trim()}',
+    };
+
+    final Map<String, String> contacto = <String, String>{};
+    void addContacto(String key, String? value) {
+      final String? normalized = _normalize(value);
+      if (normalized != null) {
+        contacto[key] = normalized;
+      }
+    }
+
+    addContacto('Telefono', telefono);
+    addContacto('Celular', celular);
+    addContacto('Correo', correoAlternativo);
+    addContacto('RedSocial', redSocial);
+    addContacto('WhatsApp', whatsapp);
+
+    final Map<String, dynamic> body = <String, dynamic>{
+      'email': email.trim(),
+      'cedula_profesional': cedula.trim(),
+      'tipo_sector': tipoSector.trim(),
+    };
+
+    final String? normalizedEspecialidad = _normalize(especialidad);
+    if (normalizedEspecialidad != null) {
+      body['especialidad'] = normalizedEspecialidad;
+    }
+
+    if (contacto.isNotEmpty) {
+      body['contacto'] = contacto;
+    }
+
+    final http.Response response = await _client.post(
+      url,
+      headers: headers,
+      body: jsonEncode(body),
+    );
+
+    Map<String, dynamic> decoded = <String, dynamic>{};
+    if (response.body.isNotEmpty) {
+      try {
+        final dynamic json = jsonDecode(response.body);
+        if (json is Map<String, dynamic>) {
+          decoded = json;
+        }
+      } catch (_) {
+        decoded = <String, dynamic>{};
+      }
+    }
+
+    if (response.statusCode == 200) {
+      return <String, dynamic>{
+        'success': true,
+        'message': decoded['message'] is String
+            ? decoded['message'] as String
+            : 'Perfil de terapeuta actualizado correctamente para el marketplace.',
+        'data': decoded['data'] is Map<String, dynamic>
+            ? decoded['data'] as Map<String, dynamic>
+            : <String, dynamic>{},
+      };
+    }
+
+    final String errorMessage = decoded['message'] is String
+        ? decoded['message'] as String
+        : 'Error al comunicarse con el servicio (código ${response.statusCode}).';
+    throw MarketplaceApiException(response.statusCode, errorMessage);
+  }
+
+  @Deprecated('Usa upsertTutorProfile en su lugar')
   Future<void> upsertProfile(Map<String, dynamic> payload) async {
-    final uri = Uri.parse('$_base/marketplace/terapeuta/profile');
-    final res = await _client.post(
-      uri,
-      headers: const {'Content-Type': 'application/json'},
+    final Uri url =
+        Uri.parse('https://xpressatec.online/marketplace/terapeuta/profile');
+    final http.Response res = await _client.post(
+      url,
+      headers: const {'Content-Type': 'application/json; charset=utf-8'},
       body: jsonEncode(payload),
     );
     if (res.statusCode != 200 && res.statusCode != 201) {

--- a/lib/presentation/features/marketplace/controllers/tutor_profile_controller.dart
+++ b/lib/presentation/features/marketplace/controllers/tutor_profile_controller.dart
@@ -6,92 +6,45 @@ import 'package:xpressatec/presentation/features/auth/controllers/auth_controlle
 
 class TutorProfileController extends GetxController {
   TutorProfileController({
-    MarketplaceApiDatasource? marketplaceApi,
-    AuthController? authController,
-    LocalStorage? localStorage,
-  })  : marketplaceApi = marketplaceApi ?? Get.find<MarketplaceApiDatasource>(),
-        authController = authController ?? Get.find<AuthController>(),
-        _localStorage = localStorage ?? (Get.isRegistered<LocalStorage>() ? Get.find<LocalStorage>() : null);
+    required this.datasource,
+    required this.authController,
+    required this.localStorage,
+  });
 
-  final MarketplaceApiDatasource marketplaceApi;
+  final MarketplaceApiDatasource datasource;
   final AuthController authController;
-  final LocalStorage? _localStorage;
+  final LocalStorage localStorage;
 
-  final formKey = GlobalKey<FormState>();
-  final isSaving = false.obs;
-  final selectedSector = 'PR'.obs;
+  final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+  final RxBool isSaving = false.obs;
+  final RxString selectedSector = 'PR'.obs;
 
-  final emailCtrl = TextEditingController();
-  final cedulaCtrl = TextEditingController();
-  final especialidadCtrl = TextEditingController();
-  final telCtrl = TextEditingController();
-  final celCtrl = TextEditingController();
-  final correoAltCtrl = TextEditingController();
-  final redSocialCtrl = TextEditingController();
-  final waCtrl = TextEditingController();
+  final TextEditingController emailCtrl = TextEditingController();
+  final TextEditingController cedulaCtrl = TextEditingController();
+  final TextEditingController especialidadCtrl = TextEditingController();
+  final TextEditingController telCtrl = TextEditingController();
+  final TextEditingController celCtrl = TextEditingController();
+  final TextEditingController correoAltCtrl = TextEditingController();
+  final TextEditingController redSocialCtrl = TextEditingController();
+  final TextEditingController waCtrl = TextEditingController();
 
   @override
   void onInit() {
     super.onInit();
-    _initializeEmail();
+    final String userEmail = _resolveUserEmail();
+    emailCtrl.text = userEmail;
   }
 
-  Future<void> _initializeEmail() async {
-    final String? email = _getEmailFromAuth();
-    if (email != null) {
-      emailCtrl.text = email;
-      return;
+  String _resolveUserEmail() {
+    final String reactiveEmail = authController.userEmail.value.trim();
+    if (reactiveEmail.isNotEmpty) {
+      return reactiveEmail;
     }
-
-    final String? storedEmail = await _getEmailFromStorage();
-    if (storedEmail != null) {
-      emailCtrl.text = storedEmail;
-      authController.userEmail.value = storedEmail;
+    final String? currentEmail = authController.currentUser.value?.email;
+    if (currentEmail != null && currentEmail.trim().isNotEmpty) {
+      return currentEmail.trim();
     }
-  }
-
-  String? _getEmailFromAuth() {
-    final String emailFromState = authController.userEmail.value.trim();
-    if (emailFromState.isNotEmpty) {
-      return emailFromState;
-    }
-
-    final String? emailFromUser = authController.currentUser.value?.email;
-    if (emailFromUser != null && emailFromUser.trim().isNotEmpty) {
-      final String normalized = emailFromUser.trim();
-      authController.userEmail.value = normalized;
-      return normalized;
-    }
-
-    return null;
-  }
-
-  Future<String?> _getEmailFromStorage() async {
-    final LocalStorage? storage = _localStorage;
-    if (storage == null) {
-      return null;
-    }
-
-    try {
-      final Map<String, dynamic>? storedUser = await storage.getUser();
-      if (storedUser == null) {
-        return null;
-      }
-
-      final dynamic emailCandidate = storedUser['email'] ??
-          storedUser['Email'] ??
-          storedUser['correo'] ??
-          storedUser['Correo'];
-      if (emailCandidate is String) {
-        final String normalized = emailCandidate.trim();
-        if (normalized.isNotEmpty) {
-          return normalized;
-        }
-      }
-    } catch (_) {
-      // Ignored: fallback retrieval should not break initialization
-    }
-    return null;
+    return '';
   }
 
   void changeSector(String sector) {
@@ -123,71 +76,36 @@ class TutorProfileController extends GetxController {
     if (isSaving.value) return;
     if (!(formKey.currentState?.validate() ?? false)) return;
 
-    final String email = emailCtrl.text.trim();
-    final String cedula = cedulaCtrl.text.trim();
-    if (email.isEmpty || cedula.isEmpty) {
-      Get.snackbar('Campos requeridos', 'Email y cédula profesional son obligatorios');
-      return;
-    }
-
     isSaving.value = true;
+    final String? token = localStorage.getToken();
+
     try {
-      final Map<String, dynamic> payload = {
-        'email': email,
-        'cedula_profesional': cedula,
-        'especialidad': _opt(especialidadCtrl.text),
-        'tipo_sector': selectedSector.value,
-        'contacto': _compact({
-          'Telefono': _opt(telCtrl.text),
-          'Celular': _opt(celCtrl.text),
-          'Correo': _opt(correoAltCtrl.text),
-          'RedSocial': _opt(redSocialCtrl.text),
-          'WhatsApp': _opt(waCtrl.text),
-        }),
-      };
+      final Map<String, dynamic> result = await datasource.upsertTutorProfile(
+        email: emailCtrl.text.trim(),
+        cedula: cedulaCtrl.text.trim(),
+        especialidad: especialidadCtrl.text.trim(),
+        tipoSector: selectedSector.value,
+        telefono: telCtrl.text,
+        celular: celCtrl.text,
+        correoAlternativo: correoAltCtrl.text,
+        redSocial: redSocialCtrl.text,
+        whatsapp: waCtrl.text,
+        token: token,
+      );
 
-      payload.removeWhere((key, value) => value == null || (value is Map && value.isEmpty));
-
-      await marketplaceApi.upsertProfile(payload);
-
-      Get.snackbar('Éxito', 'Perfil actualizado correctamente');
+      final String message = (result['message'] as String?) ??
+          'Perfil de terapeuta actualizado correctamente para el marketplace.';
+      Get.snackbar('Éxito', message);
     } on MarketplaceApiException catch (e) {
-      if (e.statusCode == 404) {
-        Get.snackbar('No encontrado', 'No existe un usuario con ese correo');
-      } else if (e.statusCode == 400) {
-        Get.snackbar('Datos inválidos', 'Faltan email y/o cédula profesional');
-      } else {
-        Get.snackbar('Error', e.message ?? 'Error de servidor');
-      }
+      final String backendMessage = (e.message ?? '').trim().isNotEmpty
+          ? e.message!.trim()
+          : 'Ocurrió un error al actualizar el perfil.';
+      Get.snackbar('Error', backendMessage);
     } catch (e) {
       Get.snackbar('Error', e.toString());
     } finally {
       isSaving.value = false;
     }
-  }
-
-  String? _opt(String? value) {
-    final String trimmed = (value ?? '').trim();
-    return trimmed.isEmpty ? null : trimmed;
-  }
-
-  Map<String, dynamic> _compact(Map<String, dynamic?> source) {
-    final Map<String, dynamic> result = <String, dynamic>{};
-    source.forEach((String key, dynamic value) {
-      if (value == null) {
-        return;
-      }
-      if (value is String) {
-        final String trimmed = value.trim();
-        if (trimmed.isEmpty) {
-          return;
-        }
-        result[key] = trimmed;
-      } else {
-        result[key] = value;
-      }
-    });
-    return result;
   }
 
   @override

--- a/lib/presentation/features/therapists/screens/tutor_profile_upload_screen.dart
+++ b/lib/presentation/features/therapists/screens/tutor_profile_upload_screen.dart
@@ -66,12 +66,13 @@ class _TutorProfileUploadScreenState extends State<TutorProfileUploadScreen> {
                   _buildSectionTitle(context, 'Datos profesionales'),
                   const SizedBox(height: 12),
                   _buildRequiredField(
-                    label: 'Correo electrónico',
+                    label: 'Correo electrónico (usuario)',
                     controller: controller.emailCtrl,
                     readOnly: true,
                     keyboardType: TextInputType.emailAddress,
                     validator: controller.validateEmail,
-                    helperText: 'Este correo identifica tu perfil en el marketplace',
+                    helperText:
+                        'Este correo identifica tu perfil en el marketplace.',
                   ),
                   const SizedBox(height: 16),
                   _buildRequiredField(
@@ -79,19 +80,27 @@ class _TutorProfileUploadScreenState extends State<TutorProfileUploadScreen> {
                     controller: controller.cedulaCtrl,
                     textCapitalization: TextCapitalization.characters,
                     validator: controller.validateCedula,
+                    helperText:
+                        'Este dato se enviará como cédula_profesional al marketplace.',
                   ),
                   const SizedBox(height: 16),
                   _buildOptionalField(
-                    label: 'Especialidad',
+                    label: 'Especialidad (opcional)',
                     controller: controller.especialidadCtrl,
                     textCapitalization: TextCapitalization.sentences,
                   ),
                   const SizedBox(height: 24),
-                  _buildSectionTitle(context, 'Sector de servicio'),
+                  _buildSectionTitle(context, 'Sector de servicio (tipo_sector)'),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Selecciona el sector en el que das servicio. Se enviará como tipo_sector: PR (Privado), PU (Público), AM (Ambos).',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
                   const SizedBox(height: 12),
                   _buildSectorSelector(context),
                   const SizedBox(height: 24),
-                  _buildSectionTitle(context, 'Contacto'),
+                  _buildSectionTitle(
+                      context, 'Contacto (se enviará como objeto "contacto")'),
                   const SizedBox(height: 12),
                   _buildOptionalField(
                     label: 'Teléfono',


### PR DESCRIPTION
## Summary
- ensure the marketplace `upsertTutorProfile` call posts to the deployed endpoint with trimmed payload data, optional contact map, and conditional authorization header
- align `TutorProfileController` to prefill the email, forward the auth token, and surface backend feedback via GetX snackbars when saving
- refresh `TutorProfileUploadScreen` copy so the UI matches the keys sent to the API

## Testing
- flutter analyze *(fails: Flutter SDK not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69167fdf50f0832f976865ebaa435e1c)