### PR TITLE
Restrict marketplace drawer action to therapists

### DIFF
--- a/lib/presentation/features/home/widgets/custom_drawer.dart
+++ b/lib/presentation/features/home/widgets/custom_drawer.dart
@@ -117,18 +117,23 @@ class CustomDrawer extends StatelessWidget {
             );
           }),
           Obx(() {
-            if (authController.isTerapeuta) {
-              return Padding(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-                child: DrawerActionCard(
-                  leadingIcon: Icons.cloud_upload_outlined,
-                  title: 'Subir información',
-                  subtitle: 'Actualiza tu perfil profesional en el marketplace',
-                  onTap: () => Get.to(() => const TutorProfileUploadScreen()),
-                ),
-              );
+            final String userRole =
+                authController.currentUser.value?.rol ??
+                    authController.userRole.value;
+
+            if (userRole != 'Terapeuta') {
+              return const SizedBox.shrink();
             }
-            return const SizedBox.shrink();
+
+            return Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+              child: DrawerActionCard(
+                leadingIcon: Icons.cloud_upload_outlined,
+                title: 'Subir información',
+                subtitle: 'Actualiza tu perfil profesional en el marketplace',
+                onTap: () => Get.to(() => const TutorProfileUploadScreen()),
+              ),
+            );
           }),
           const Divider(),
           ListTile(


### PR DESCRIPTION
## Summary
- ensure the marketplace drawer card is only rendered when the authenticated user role is Terapeuta
- rely on the AuthController role information so tutors and patients never see the marketplace entry

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69169259e088832f99bc3304a48986f3)