### PR TITLE
style: refresh therapist marketplace and detail ui

### DIFF
--- a/lib/presentation/features/therapists/screens/communication_therapist_marketplace_screen.dart
+++ b/lib/presentation/features/therapists/screens/communication_therapist_marketplace_screen.dart
@@ -19,7 +19,7 @@ class CommunicationTherapistMarketplaceScreen
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    final Color backgroundTint = colorScheme.primary.withOpacity(0.06);
+    final Color backgroundTint = colorScheme.primary.withOpacity(0.05);
 
     return Scaffold(
       backgroundColor: backgroundTint,
@@ -30,18 +30,18 @@ class CommunicationTherapistMarketplaceScreen
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const SizedBox(height: 16),
+              const SizedBox(height: 12),
               Text(
                 'Terapeutas en comunicación',
                 style: theme.textTheme.headlineSmall?.copyWith(
-                  color: colorScheme.primary,
-                  fontWeight: FontWeight.bold,
+                  color: colorScheme.onSurface,
+                  fontWeight: FontWeight.w700,
                 ),
               ),
-              const SizedBox(height: 8),
+              const SizedBox(height: 6),
               Text(
                 'Explora especialistas en comunicación y lenguaje.',
-                style: theme.textTheme.bodyMedium?.copyWith(
+                style: theme.textTheme.bodyLarge?.copyWith(
                   color: colorScheme.onSurface.withOpacity(0.7),
                 ),
               ),
@@ -50,7 +50,7 @@ class CommunicationTherapistMarketplaceScreen
                 controller: controller.searchCtrl,
                 onChanged: controller.onSearchChanged,
               ),
-              const SizedBox(height: 20),
+              const SizedBox(height: 24),
               Expanded(
                 child: Obx(() {
                   if (controller.isLoading.value) {
@@ -68,10 +68,12 @@ class CommunicationTherapistMarketplaceScreen
 
                   return ListView.separated(
                     itemCount: terapeutas.length,
-                    separatorBuilder: (_, __) => const SizedBox(height: 16),
+                    physics: const BouncingScrollPhysics(),
+                    padding: const EdgeInsets.only(bottom: 12),
+                    separatorBuilder: (_, __) => const SizedBox(height: 18),
                     itemBuilder: (context, index) {
                       final TerapeutaMarketplace terapeuta = terapeutas[index];
-                      return _TherapistListTile(
+                      return _TherapistCard(
                         terapeuta: terapeuta,
                         colorScheme: colorScheme,
                       );
@@ -101,35 +103,47 @@ class _SearchField extends StatelessWidget {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(28),
-        boxShadow: [
-          BoxShadow(
-            color: colorScheme.primary.withOpacity(0.08),
-            blurRadius: 18,
-            offset: const Offset(0, 8),
-          ),
-        ],
+    return TextField(
+      controller: controller,
+      onChanged: onChanged,
+      style: theme.textTheme.bodyLarge?.copyWith(
+        color: colorScheme.onSurface,
       ),
-      child: TextField(
-        controller: controller,
-        onChanged: onChanged,
-        decoration: InputDecoration(
-          hintText: 'Buscar por nombre, ciudad o especialidad',
-          prefixIcon: Icon(Icons.search, color: colorScheme.primary),
-          border: InputBorder.none,
-          contentPadding:
-              const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      decoration: InputDecoration(
+        filled: true,
+        fillColor: colorScheme.surface,
+        hintText: 'Buscar por nombre, ciudad o especialidad',
+        hintStyle: theme.textTheme.bodyLarge?.copyWith(
+          color: colorScheme.onSurface.withOpacity(0.5),
+        ),
+        prefixIcon: Icon(Icons.search, color: colorScheme.primary),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(32),
+          borderSide: BorderSide(
+            color: colorScheme.primary.withOpacity(0.15),
+          ),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(32),
+          borderSide: BorderSide(
+            color: colorScheme.primary.withOpacity(0.15),
+          ),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(32),
+          borderSide: BorderSide(
+            color: colorScheme.primary.withOpacity(0.35),
+            width: 1.6,
+          ),
         ),
       ),
     );
   }
 }
 
-class _TherapistListTile extends StatelessWidget {
-  const _TherapistListTile({
+class _TherapistCard extends StatelessWidget {
+  const _TherapistCard({
     required this.terapeuta,
     required this.colorScheme,
   });
@@ -150,6 +164,27 @@ class _TherapistListTile extends StatelessWidget {
     }
   }
 
+  List<_ContactChipData> _buildContactChips(Map<String, dynamic> contacto) {
+    final List<_ContactChipData> contactChips = [];
+
+    void addChip(IconData icon, String label, String? value) {
+      if (value == null) return;
+      final String trimmed = value.trim();
+      if (trimmed.isEmpty) return;
+      contactChips.add(
+        _ContactChipData(icon: icon, label: label, value: trimmed),
+      );
+    }
+
+    addChip(Icons.phone_outlined, 'Teléfono', contacto['Telefono'] as String?);
+    addChip(Icons.smartphone_outlined, 'Celular', contacto['Celular'] as String?);
+    addChip(Icons.email_outlined, 'Correo', contacto['Correo'] as String?);
+    addChip(Icons.alternate_email, 'Red social', contacto['RedSocial'] as String?);
+    addChip(Icons.whatsapp, 'WhatsApp', contacto['WhatsApp'] as String?);
+
+    return contactChips;
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -157,158 +192,336 @@ class _TherapistListTile extends StatelessWidget {
         (terapeuta.especialidad?.trim().isNotEmpty ?? false)
             ? terapeuta.especialidad!.trim()
             : 'Sin especialidad';
-    final Map<String, dynamic> contacto = terapeuta.contacto;
 
-    final List<_ContactChipData> contactChips = [];
-    void addChip(IconData icon, String label, String? value) {
-      if (value == null) return;
-      final String trimmed = value.trim();
-      if (trimmed.isEmpty) return;
-      contactChips.add(_ContactChipData(icon: icon, label: label, value: trimmed));
-    }
+    final List<_ContactChipData> contactChips =
+        _buildContactChips(terapeuta.contacto);
 
-    addChip(Icons.phone, 'Teléfono', contacto['Telefono'] as String?);
-    addChip(Icons.smartphone, 'Celular', contacto['Celular'] as String?);
-    addChip(Icons.email_outlined, 'Correo', contacto['Correo'] as String?);
-    addChip(Icons.alternate_email, 'Red social', contacto['RedSocial'] as String?);
-    addChip(Icons.whatsapp, 'WhatsApp', contacto['WhatsApp'] as String?);
-
-    return InkWell(
-      borderRadius: BorderRadius.circular(24),
-      onTap: () {
-        Get.toNamed(
-          Routes.therapistDetail,
-          arguments: terapeuta,
-        );
-      },
-      child: Ink(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(24),
-          color: Colors.white,
-          boxShadow: [
-            BoxShadow(
-              color: colorScheme.primary.withOpacity(0.12),
-              blurRadius: 24,
-              offset: const Offset(0, 12),
-            ),
-          ],
-          border: Border.all(color: colorScheme.primary.withOpacity(0.15)),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          terapeuta.nombre,
-                          style: theme.textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.w800,
-                            color: colorScheme.onSurface,
-                          ),
-                        ),
-                        const SizedBox(height: 6),
-                        Text(
-                          especialidad,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            color: colorScheme.primary,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Container(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                    decoration: BoxDecoration(
-                      color: colorScheme.primary.withOpacity(0.12),
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: [
-                        Text(
-                          _sectorLabel(terapeuta.tipoSector),
-                          style: theme.textTheme.labelMedium?.copyWith(
-                            color: colorScheme.primary,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        Text(
-                          terapeuta.tipoSector,
-                          style: theme.textTheme.labelSmall?.copyWith(
-                            color: colorScheme.primary.withOpacity(0.7),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              Row(
-                children: [
-                  Icon(Icons.badge_outlined, size: 18, color: colorScheme.primary),
-                  const SizedBox(width: 8),
-                  Text(
-                    'Cédula: ${terapeuta.cedulaProfesional}',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: colorScheme.onSurface.withOpacity(0.75),
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 12),
-              Row(
-                children: [
-                  Icon(Icons.mail_outline, size: 18, color: colorScheme.primary),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      terapeuta.email,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: colorScheme.onSurface.withOpacity(0.7),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              if (contactChips.isNotEmpty) ...[
-                const SizedBox(height: 16),
-                Wrap(
-                  spacing: 10,
-                  runSpacing: 8,
-                  children: contactChips
-                      .map(
-                        (chip) => _ContactChip(
-                          data: chip,
-                          colorScheme: colorScheme,
-                          theme: theme,
-                        ),
-                      )
-                      .toList(),
-                ),
-              ],
-            ],
-          ),
-        ),
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(28),
         onTap: () {
           Get.toNamed(
             Routes.therapistDetail,
             arguments: terapeuta,
           );
         },
+        child: Ink(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [
+                colorScheme.surface,
+                colorScheme.surfaceVariant.withOpacity(0.45),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(28),
+            border: Border.all(color: colorScheme.primary.withOpacity(0.08)),
+            boxShadow: [
+              BoxShadow(
+                color: colorScheme.primary.withOpacity(0.08),
+                blurRadius: 30,
+                offset: const Offset(0, 18),
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _AvatarBadge(colorScheme: colorScheme, name: terapeuta.nombre),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            terapeuta.nombre,
+                            style: theme.textTheme.titleLarge?.copyWith(
+                              color: colorScheme.onSurface,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          Text(
+                            especialidad,
+                            style: theme.textTheme.bodyLarge?.copyWith(
+                              color: colorScheme.primary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    _SectorBadge(
+                      label: _sectorLabel(terapeuta.tipoSector),
+                      code: terapeuta.tipoSector,
+                      colorScheme: colorScheme,
+                      theme: theme,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 12,
+                  children: [
+                    _InfoPill(
+                      icon: Icons.badge_outlined,
+                      label: 'Cédula',
+                      value: terapeuta.cedulaProfesional,
+                    ),
+                    _InfoPill(
+                      icon: Icons.mail_outline,
+                      label: 'Correo principal',
+                      value: terapeuta.email,
+                    ),
+                  ],
+                ),
+                if (contactChips.isNotEmpty) ...[
+                  const SizedBox(height: 18),
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 12,
+                    children: contactChips
+                        .map((chip) => _ContactChip(data: chip))
+                        .toList(),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }
+}
+
+class _AvatarBadge extends StatelessWidget {
+  const _AvatarBadge({
+    required this.colorScheme,
+    required this.name,
+  });
+
+  final ColorScheme colorScheme;
+  final String name;
+
+  @override
+  Widget build(BuildContext context) {
+    final initials = name.trim().isNotEmpty
+        ? name.trim().split(' ').take(2).map((e) => e[0]).join().toUpperCase()
+        : 'TX';
+
+    return Container(
+      width: 64,
+      height: 64,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: LinearGradient(
+          colors: [
+            colorScheme.primary.withOpacity(0.35),
+            colorScheme.secondary.withOpacity(0.2),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.primary.withOpacity(0.14),
+            blurRadius: 24,
+            offset: const Offset(0, 12),
+          ),
+        ],
+      ),
+      child: Center(
+        child: Text(
+          initials,
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                color: colorScheme.onSurface,
+                fontWeight: FontWeight.bold,
+              ) ??
+              TextStyle(
+                color: colorScheme.onSurface,
+                fontWeight: FontWeight.bold,
+                fontSize: 20,
+              ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectorBadge extends StatelessWidget {
+  const _SectorBadge({
+    required this.label,
+    required this.code,
+    required this.colorScheme,
+    required this.theme,
+  });
+
+  final String label;
+  final String code;
+  final ColorScheme colorScheme;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      decoration: BoxDecoration(
+        color: colorScheme.secondary.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: colorScheme.secondary.withOpacity(0.2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: colorScheme.secondary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          Text(
+            code,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: colorScheme.secondary.withOpacity(0.7),
+              letterSpacing: 1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoPill extends StatelessWidget {
+  const _InfoPill({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: colorScheme.surface.withOpacity(0.9),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: colorScheme.primary.withOpacity(0.1)),
+      ),
+      constraints: const BoxConstraints(minWidth: 120, maxWidth: 240),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 20, color: colorScheme.primary),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: colorScheme.onSurface.withOpacity(0.6),
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  value,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurface,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ContactChip extends StatelessWidget {
+  const _ContactChip({required this.data});
+
+  final _ContactChipData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: colorScheme.secondary.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: colorScheme.secondary.withOpacity(0.18)),
+      ),
+      constraints: const BoxConstraints(minWidth: 140, maxWidth: 220),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(data.icon, size: 20, color: colorScheme.secondary),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  data.label,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: colorScheme.secondary.withOpacity(0.8),
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  data.value,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ContactChipData {
+  const _ContactChipData({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
 }
 
 class _EmptyResultsMessage extends StatelessWidget {
@@ -325,29 +538,43 @@ class _EmptyResultsMessage extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(Icons.search_off, size: 48, color: colorScheme.primary),
-          const SizedBox(height: 12),
-          Text(
-            'No encontramos terapeutas',
-            style: theme.textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.bold,
-              color: colorScheme.primary,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+        decoration: BoxDecoration(
+          color: colorScheme.surface,
+          borderRadius: BorderRadius.circular(28),
+          boxShadow: [
+            BoxShadow(
+              color: colorScheme.primary.withOpacity(0.08),
+              blurRadius: 28,
+              offset: const Offset(0, 16),
             ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            query.isEmpty
-                ? 'Intenta buscar por especialidad o ciudad.'
-                : 'No hay resultados para "$query". Prueba con otro término.',
-            textAlign: TextAlign.center,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: colorScheme.onSurface.withOpacity(0.7),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.search_off_rounded, size: 52, color: colorScheme.primary),
+            const SizedBox(height: 16),
+            Text(
+              'No encontramos terapeutas',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: colorScheme.primary,
+              ),
             ),
-          ),
-        ],
+            const SizedBox(height: 10),
+            Text(
+              query.isEmpty
+                  ? 'Intenta buscar por especialidad o ciudad.'
+                  : 'No hay resultados para "$query". Prueba con otro término.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurface.withOpacity(0.7),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/presentation/features/therapists/screens/therapist_detail_screen.dart
+++ b/lib/presentation/features/therapists/screens/therapist_detail_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:xpressatec/data/models/terapeuta_marketplace.dart';
 
+import '../../../shared/widgets/xpressatec_header_appbar.dart';
+
 class TherapistDetailScreen extends StatelessWidget {
   const TherapistDetailScreen({super.key});
 
@@ -23,15 +25,17 @@ class TherapistDetailScreen extends StatelessWidget {
 
     void addIfValid(String label, IconData icon, String? value) {
       if (value != null && value.trim().isNotEmpty) {
-        contactInfo.add(_ContactInfo(label: label, value: value.trim(), icon: icon));
+        contactInfo.add(
+          _ContactInfo(label: label, value: value.trim(), icon: icon),
+        );
       }
     }
 
-    addIfValid('Teléfono', Icons.phone, contacto['Telefono'] as String?);
-    addIfValid('Celular', Icons.smartphone, contacto['Celular'] as String?);
+    addIfValid('Teléfono', Icons.phone_outlined, contacto['Telefono'] as String?);
+    addIfValid('Celular', Icons.smartphone_outlined, contacto['Celular'] as String?);
     addIfValid('Correo', Icons.email_outlined, contacto['Correo'] as String?);
     addIfValid('Red social', Icons.alternate_email, contacto['RedSocial'] as String?);
-    addIfValid('WhatsApp', Icons.chat, contacto['WhatsApp'] as String?);
+    addIfValid('WhatsApp', Icons.chat_outlined, contacto['WhatsApp'] as String?);
 
     return contactInfo;
   }
@@ -43,20 +47,17 @@ class TherapistDetailScreen extends StatelessWidget {
         arguments is TerapeutaMarketplace ? arguments : null;
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final Color backgroundTint = colorScheme.primary.withOpacity(0.05);
 
     if (terapeuta == null) {
       return Scaffold(
-        appBar: AppBar(
-          title: const Text('Detalle del terapeuta'),
-          leading: IconButton(
-            icon: const Icon(Icons.arrow_back),
-            onPressed: Get.back,
-          ),
-        ),
+        backgroundColor: backgroundTint,
+        appBar: const XpressatecHeaderAppBar(showBack: true),
         body: Center(
           child: Text(
             'No se pudo cargar la información del terapeuta.',
             style: theme.textTheme.bodyLarge,
+            textAlign: TextAlign.center,
           ),
         ),
       );
@@ -70,119 +71,327 @@ class TherapistDetailScreen extends StatelessWidget {
         _buildContactInfo(terapeuta.contacto);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Detalle del terapeuta'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: Get.back,
-        ),
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(20),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Card(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(16),
+      backgroundColor: backgroundTint,
+      appBar: const XpressatecHeaderAppBar(showBack: true),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _TherapistHeroCard(
+                terapeuta: terapeuta,
+                especialidad: especialidad,
+                sectorLabel: _sectorLabel(terapeuta.tipoSector),
               ),
-              elevation: 2,
-              child: Padding(
-                padding: const EdgeInsets.all(20),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      terapeuta.nombre,
-                      style: theme.textTheme.headlineSmall?.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: colorScheme.primary,
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-                    Text(
-                      especialidad,
-                      style: theme.textTheme.titleMedium?.copyWith(
-                        color: colorScheme.onSurface.withOpacity(0.8),
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-                    _DetailRow(
-                      label: 'Cédula profesional',
-                      value: terapeuta.cedulaProfesional,
-                    ),
-                    const SizedBox(height: 8),
-                    _DetailRow(
-                      label: 'Sector',
-                      value: _sectorLabel(terapeuta.tipoSector),
-                    ),
-                    const SizedBox(height: 8),
-                    _DetailRow(
-                      label: 'Correo principal',
-                      value: terapeuta.email,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            const SizedBox(height: 24),
-            Text(
-              'Datos de contacto',
-              style: theme.textTheme.titleLarge?.copyWith(
-                fontWeight: FontWeight.bold,
-                color: colorScheme.primary,
-              ),
-            ),
-            const SizedBox(height: 12),
-            if (contactItems.isEmpty)
-              Card(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                elevation: 1,
+              const SizedBox(height: 28),
+              const _SectionTitle('Información profesional'),
+              const SizedBox(height: 16),
+              _ElevatedContainer(
                 child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Text(
-                    'No hay información de contacto adicional disponible.',
-                    style: theme.textTheme.bodyMedium,
+                  padding: const EdgeInsets.all(24),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _DetailTile(
+                        icon: Icons.badge_outlined,
+                        label: 'Cédula profesional',
+                        value: terapeuta.cedulaProfesional,
+                      ),
+                      const SizedBox(height: 12),
+                      _DetailTile(
+                        icon: Icons.workspace_premium_outlined,
+                        label: 'Especialidad',
+                        value: especialidad,
+                      ),
+                      const SizedBox(height: 12),
+                      _DetailTile(
+                        icon: Icons.apartment_outlined,
+                        label: 'Sector',
+                        value: _sectorLabel(terapeuta.tipoSector),
+                      ),
+                      const SizedBox(height: 12),
+                      _DetailTile(
+                        icon: Icons.mail_outline,
+                        label: 'Correo principal',
+                        value: terapeuta.email,
+                      ),
+                    ],
                   ),
                 ),
-              )
-            else
-              Column(
-                children: contactItems
-                    .map(
-                      (item) => Card(
-                        margin: const EdgeInsets.only(bottom: 12),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        elevation: 1,
-                        child: ListTile(
-                          leading: Icon(
-                            item.icon,
-                            color: colorScheme.primary,
-                          ),
-                          title: Text(item.label),
-                          subtitle: Text(item.value),
-                        ),
-                      ),
-                    )
-                    .toList(),
               ),
-          ],
+              const SizedBox(height: 28),
+              const _SectionTitle('Datos de contacto'),
+              const SizedBox(height: 16),
+              if (contactItems.isEmpty)
+                _ElevatedContainer(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+                    child: Text(
+                      'No hay información de contacto adicional disponible.',
+                      style: theme.textTheme.bodyLarge?.copyWith(
+                        color: colorScheme.onSurface.withOpacity(0.7),
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                )
+              else
+                Column(
+                  children: contactItems
+                      .map(
+                        (item) => Padding(
+                          padding: const EdgeInsets.only(bottom: 16),
+                          child: _ContactTile(info: item),
+                        ),
+                      )
+                      .toList(),
+                ),
+            ],
+          ),
         ),
       ),
     );
   }
 }
 
-class _DetailRow extends StatelessWidget {
-  const _DetailRow({
+class _TherapistHeroCard extends StatelessWidget {
+  const _TherapistHeroCard({
+    required this.terapeuta,
+    required this.especialidad,
+    required this.sectorLabel,
+  });
+
+  final TerapeutaMarketplace terapeuta;
+  final String especialidad;
+  final String sectorLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final initials = terapeuta.nombre.trim().isNotEmpty
+        ? terapeuta.nombre
+            .trim()
+            .split(' ')
+            .where((element) => element.isNotEmpty)
+            .take(2)
+            .map((e) => e[0])
+            .join()
+            .toUpperCase()
+        : 'TX';
+
+    return Container(
+      padding: const EdgeInsets.all(28),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            colorScheme.primary.withOpacity(0.3),
+            colorScheme.secondary.withOpacity(0.18),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(32),
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.primary.withOpacity(0.12),
+            blurRadius: 36,
+            offset: const Offset(0, 20),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 88,
+                height: 88,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: colorScheme.surface.withOpacity(0.9),
+                  boxShadow: [
+                    BoxShadow(
+                      color: colorScheme.primary.withOpacity(0.16),
+                      blurRadius: 24,
+                      offset: const Offset(0, 12),
+                    ),
+                  ],
+                ),
+                child: Center(
+                  child: Text(
+                    initials,
+                    style: theme.textTheme.headlineSmall?.copyWith(
+                      color: colorScheme.primary,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 20),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      terapeuta.nombre,
+                      style: theme.textTheme.headlineSmall?.copyWith(
+                        color: colorScheme.onSurface,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      especialidad,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: colorScheme.onSurface.withOpacity(0.85),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    _HeroBadge(
+                      icon: Icons.apartment_outlined,
+                      label: 'Sector',
+                      value: sectorLabel,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          Text(
+            'Contacto principal',
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.8),
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            terapeuta.email,
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: colorScheme.onSurface,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroBadge extends StatelessWidget {
+  const _HeroBadge({
+    required this.icon,
     required this.label,
     required this.value,
   });
 
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: BoxDecoration(
+        color: colorScheme.surface.withOpacity(0.85),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: colorScheme.primary.withOpacity(0.15)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 20, color: colorScheme.primary),
+          const SizedBox(width: 8),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: colorScheme.onSurface.withOpacity(0.7),
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              Text(
+                value,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurface,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  const _SectionTitle(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Text(
+      text,
+      style: theme.textTheme.titleLarge?.copyWith(
+        color: colorScheme.onSurface,
+        fontWeight: FontWeight.w700,
+      ),
+    );
+  }
+}
+
+class _ElevatedContainer extends StatelessWidget {
+  const _ElevatedContainer({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(28),
+        border: Border.all(color: colorScheme.primary.withOpacity(0.08)),
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.primary.withOpacity(0.08),
+            blurRadius: 30,
+            offset: const Offset(0, 18),
+          ),
+        ],
+      ),
+      child: child,
+    );
+  }
+}
+
+class _DetailTile extends StatelessWidget {
+  const _DetailTile({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
   final String label;
   final String value;
 
@@ -194,24 +403,93 @@ class _DetailRow extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Expanded(
-          flex: 2,
-          child: Text(
-            label,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              fontWeight: FontWeight.w600,
-              color: colorScheme.onSurface.withOpacity(0.7),
-            ),
+        Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: colorScheme.primary.withOpacity(0.12),
+            borderRadius: BorderRadius.circular(14),
           ),
+          child: Icon(icon, color: colorScheme.primary, size: 22),
         ),
+        const SizedBox(width: 14),
         Expanded(
-          flex: 3,
-          child: Text(
-            value,
-            style: theme.textTheme.bodyMedium,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: colorScheme.onSurface.withOpacity(0.7),
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                value,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: colorScheme.onSurface,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
           ),
         ),
       ],
+    );
+  }
+}
+
+class _ContactTile extends StatelessWidget {
+  const _ContactTile({required this.info});
+
+  final _ContactInfo info;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return _ElevatedContainer(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+        child: Row(
+          children: [
+            Container(
+              width: 52,
+              height: 52,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: colorScheme.primary.withOpacity(0.12),
+              ),
+              child: Icon(info.icon, color: colorScheme.primary),
+            ),
+            const SizedBox(width: 18),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    info.label,
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: colorScheme.onSurface.withOpacity(0.7),
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    info.value,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: colorScheme.onSurface,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- refresh the therapist marketplace cards, search field, and empty states to match the app color palette and typography
- redesign the therapist detail screen with a matching app bar, hero card, and elevated sections for professional and contact information

## Testing
- not run (Flutter tooling unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916c45ff868832f90ba1f57f9943fe0)