### PR TITLE
Add WhatsApp-style chat list experience

### DIFF
--- a/lib/core/config/routes.dart
+++ b/lib/core/config/routes.dart
@@ -1,6 +1,8 @@
 import 'package:get/get_navigation/src/routes/get_route.dart';
 import 'package:xpressatec/core/bindings/auth_binding.dart';
 import 'package:xpressatec/core/bindings/home_binding.dart';
+import 'package:xpressatec/presentation/features/chat/screens/chat_screen.dart';
+import 'package:xpressatec/presentation/features/chat/screens/new_chat_screen.dart';
 import 'package:xpressatec/presentation/features/auth/screens/login_screen.dart';
 import 'package:xpressatec/presentation/features/calendar/screens/tutor_calendar_screen.dart';
 import 'package:xpressatec/presentation/features/home/screens/home_screen.dart';
@@ -41,6 +43,8 @@ class Routes {
   static const String communicationTherapists = '/communication-therapists';
   static const String therapistDetail = '/marketplace/therapist-detail';
   static const String tutorProfileUpload = '/tutor-profile-upload';
+  static const String chatDetail = '/chat/detail';
+  static const String newChat = '/chat/new';
   // static const String audioTesting = '/audio-testing';
 }
 
@@ -112,6 +116,14 @@ class AppRoutes {
     GetPage(
       name: Routes.downloadPictograms,
       page: () => const DownloadPictogramsScreen(),
+    ),
+    GetPage(
+      name: Routes.chatDetail,
+      page: () => const ChatScreen(showRecipientSelector: false),
+    ),
+    GetPage(
+      name: Routes.newChat,
+      page: () => const NewChatScreen(),
     ),
 
     // GetPage(

--- a/lib/presentation/features/chat/controllers/chat_controller.dart
+++ b/lib/presentation/features/chat/controllers/chat_controller.dart
@@ -6,6 +6,45 @@ import 'package:get/get.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:xpressatec/presentation/features/auth/controllers/auth_controller.dart';
 
+class ChatConversation {
+  const ChatConversation({
+    required this.id,
+    required this.otherName,
+    required this.otherEmail,
+    required this.role,
+    required this.lastMessage,
+    required this.lastMessageTime,
+    required this.unreadCount,
+  });
+
+  final String id;
+  final String otherName;
+  final String otherEmail;
+  final String role;
+  final String lastMessage;
+  final DateTime? lastMessageTime;
+  final int unreadCount;
+
+  ChatConversation copyWith({
+    String? otherName,
+    String? otherEmail,
+    String? role,
+    String? lastMessage,
+    DateTime? lastMessageTime,
+    int? unreadCount,
+  }) {
+    return ChatConversation(
+      id: id,
+      otherName: otherName ?? this.otherName,
+      otherEmail: otherEmail ?? this.otherEmail,
+      role: role ?? this.role,
+      lastMessage: lastMessage ?? this.lastMessage,
+      lastMessageTime: lastMessageTime ?? this.lastMessageTime,
+      unreadCount: unreadCount ?? this.unreadCount,
+    );
+  }
+}
+
 class ChatMessage {
   final String from;
   final String to;
@@ -26,10 +65,13 @@ class ChatController extends GetxController {
   static const _chatUrl = 'wss://xpressatec.online/ws/chat';
 
   final RxList<ChatMessage> messages = <ChatMessage>[].obs;
+  final RxList<ChatConversation> conversations = <ChatConversation>[].obs;
   final RxBool isConnecting = false.obs;
   final RxBool isConnected = false.obs;
   final RxString connectionError = ''.obs;
   final RxString currentRecipientEmail = ''.obs;
+  final RxString currentRecipientName = ''.obs;
+  final RxString currentRecipientRole = ''.obs;
 
   final TextEditingController messageController = TextEditingController();
   final TextEditingController recipientEmailController = TextEditingController();
@@ -38,6 +80,7 @@ class ChatController extends GetxController {
   WebSocketChannel? _channel;
   StreamSubscription? _channelSubscription;
   Worker? _emailWorker;
+  Worker? _recipientWorker;
 
   String _userEmail = '';
   bool _manuallyClosed = false;
@@ -56,6 +99,12 @@ class ChatController extends GetxController {
       }
     });
 
+    _recipientWorker = ever<String>(currentRecipientEmail, (email) {
+      if (email.isNotEmpty) {
+        markConversationAsRead(email);
+      }
+    });
+
     _initializeConnection();
   }
 
@@ -63,6 +112,7 @@ class ChatController extends GetxController {
   void onClose() {
     _manuallyClosed = true;
     _emailWorker?.dispose();
+    _recipientWorker?.dispose();
     _closeChannel();
     messageController.dispose();
     recipientEmailController.dispose();
@@ -228,7 +278,11 @@ class ChatController extends GetxController {
     }
   }
 
-  void setRecipientEmail(String email) {
+  bool setRecipientEmail(
+    String email, {
+    String? displayName,
+    String? role,
+  }) {
     final trimmed = email.trim();
 
     if (trimmed.isEmpty) {
@@ -237,7 +291,7 @@ class ChatController extends GetxController {
         'Ingresa un correo para el destinatario.',
         snackPosition: SnackPosition.BOTTOM,
       );
-      return;
+      return false;
     }
 
     if (!GetUtils.isEmail(trimmed)) {
@@ -246,11 +300,21 @@ class ChatController extends GetxController {
         'Ingresa un correo válido.',
         snackPosition: SnackPosition.BOTTOM,
       );
-      return;
+      return false;
     }
+
+    final conversation = ensureConversationExists(
+      trimmed,
+      name: displayName,
+      role: role,
+    );
 
     currentRecipientEmail.value = trimmed;
     recipientEmailController.text = trimmed;
+    currentRecipientName.value = displayName ?? conversation.otherName;
+    currentRecipientRole.value = role ?? conversation.role;
+    markConversationAsRead(trimmed);
+    return true;
   }
 
   Future<void> sendMessage() async {
@@ -338,6 +402,7 @@ class ChatController extends GetxController {
   void _addMessage(ChatMessage message) {
     messages.add(message);
     messages.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    _updateConversationForMessage(message);
   }
 
   void _closeChannel() {
@@ -348,5 +413,149 @@ class ChatController extends GetxController {
     _channel = null;
 
     isConnected.value = false;
+  }
+
+  void openConversation(ChatConversation conversation) {
+    setRecipientEmail(
+      conversation.otherEmail,
+      displayName: conversation.otherName,
+      role: conversation.role,
+    );
+  }
+
+  ChatConversation ensureConversationExists(
+    String email, {
+    String? name,
+    String? role,
+  }) {
+    final trimmed = email.trim();
+    final id = _conversationKey(trimmed);
+    final index = conversations.indexWhere((conversation) => conversation.id == id);
+
+    final resolvedName = name ??
+        (index != -1 ? conversations[index].otherName : _inferNameFromEmail(trimmed));
+    final resolvedRole = role ??
+        (index != -1 ? conversations[index].role : _inferRoleForOther());
+
+    if (index == -1) {
+      final conversation = ChatConversation(
+        id: id,
+        otherName: resolvedName,
+        otherEmail: trimmed,
+        role: resolvedRole,
+        lastMessage: '',
+        lastMessageTime: null,
+        unreadCount: 0,
+      );
+      conversations.add(conversation);
+      _sortConversations();
+      return conversation;
+    }
+
+    final existing = conversations[index];
+    final shouldUpdateName = name != null && name != existing.otherName;
+    final shouldUpdateRole = role != null && role != existing.role;
+
+    if (shouldUpdateName || shouldUpdateRole) {
+      final updated = existing.copyWith(
+        otherName: resolvedName,
+        role: resolvedRole,
+      );
+      conversations[index] = updated;
+      conversations.refresh();
+      return updated;
+    }
+
+    return existing;
+  }
+
+  ChatConversation? getConversationByEmail(String email) {
+    final id = _conversationKey(email);
+    final index = conversations.indexWhere((conversation) => conversation.id == id);
+    if (index == -1) {
+      return null;
+    }
+    return conversations[index];
+  }
+
+  void markConversationAsRead(String email) {
+    final id = _conversationKey(email);
+    final index = conversations.indexWhere((conversation) => conversation.id == id);
+    if (index == -1) {
+      return;
+    }
+    final existing = conversations[index];
+    if (existing.unreadCount == 0) {
+      return;
+    }
+    conversations[index] = existing.copyWith(unreadCount: 0);
+    conversations.refresh();
+  }
+
+  void _updateConversationForMessage(ChatMessage message) {
+    final otherEmail = message.isSelf ? message.to : message.from;
+    if (otherEmail.isEmpty) {
+      return;
+    }
+
+    final conversation = ensureConversationExists(otherEmail);
+    final id = conversation.id;
+    final index = conversations.indexWhere((element) => element.id == id);
+    if (index == -1) {
+      return;
+    }
+
+    final isActive =
+        _conversationKey(currentRecipientEmail.value) == id && !message.isSelf;
+    final unreadCount = message.isSelf
+        ? 0
+        : (isActive ? 0 : conversation.unreadCount + 1);
+
+    final updatedConversation = conversation.copyWith(
+      lastMessage: message.text,
+      lastMessageTime: message.timestamp,
+      unreadCount: unreadCount,
+    );
+
+    conversations[index] = updatedConversation;
+    _sortConversations();
+  }
+
+  void _sortConversations() {
+    conversations.sort((a, b) {
+      final aTime = a.lastMessageTime ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final bTime = b.lastMessageTime ?? DateTime.fromMillisecondsSinceEpoch(0);
+      return bTime.compareTo(aTime);
+    });
+    conversations.refresh();
+  }
+
+  String _conversationKey(String email) => email.trim().toLowerCase();
+
+  String _inferNameFromEmail(String email) {
+    final value = email.trim();
+    if (value.isEmpty) {
+      return 'Contacto';
+    }
+    final prefix = value.split('@').first;
+    if (prefix.isEmpty) {
+      return value;
+    }
+    return prefix
+        .split(RegExp(r'[._]'))
+        .where((segment) => segment.isNotEmpty)
+        .map((segment) => segment[0].toUpperCase() + segment.substring(1))
+        .join(' ')
+        .trim();
+  }
+
+  String _inferRoleForOther() {
+    if (_authController.isTutor) {
+      return 'Terapeuta';
+    }
+    if (_authController.isTerapeuta) {
+      return 'Tutor';
+    }
+    return 'Contacto';
   }
 }

--- a/lib/presentation/features/chat/screens/chat_list_screen.dart
+++ b/lib/presentation/features/chat/screens/chat_list_screen.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+import 'package:xpressatec/core/config/routes.dart';
+import 'package:xpressatec/presentation/features/chat/controllers/chat_controller.dart';
+
+class ChatListScreen extends GetView<ChatController> {
+  const ChatListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return SafeArea(
+      top: false,
+      child: Obx(() {
+        final conversations = controller.conversations;
+        if (conversations.isEmpty) {
+          return ChatEmptyState(colorScheme: colorScheme, theme: theme);
+        }
+
+        return ListView.separated(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+        itemBuilder: (context, index) {
+          final conversation = conversations[index];
+          return ChatListTile(
+            conversation: conversation,
+            onTap: () {
+              controller.openConversation(conversation);
+              Get.toNamed(
+                Routes.chatDetail,
+                arguments: conversation,
+              );
+            },
+          );
+        },
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemCount: conversations.length,
+      );
+      }),
+    );
+  }
+}
+
+class ChatListTile extends StatelessWidget {
+  const ChatListTile({
+    super.key,
+    required this.conversation,
+    required this.onTap,
+  });
+
+  final ChatConversation conversation;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final timeFormatter = DateFormat('HH:mm');
+    final hasLastMessage = conversation.lastMessage.isNotEmpty;
+    final displayMessage = hasLastMessage ? conversation.lastMessage : 'Sin mensajes aún';
+    final lastMessageTime = conversation.lastMessageTime;
+    final displayTime = lastMessageTime != null ? timeFormatter.format(lastMessageTime) : '';
+    final initial = conversation.otherName.isNotEmpty
+        ? conversation.otherName.characters.first.toUpperCase()
+        : (conversation.otherEmail.isNotEmpty
+            ? conversation.otherEmail.characters.first.toUpperCase()
+            : '?');
+
+    return Card(
+      color: colorScheme.surface,
+      elevation: 0,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(18),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              CircleAvatar(
+                radius: 26,
+                backgroundColor: colorScheme.primary.withOpacity(0.12),
+                child: Text(
+                  initial,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: colorScheme.primary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            conversation.otherName.isNotEmpty
+                                ? conversation.otherName
+                                : conversation.otherEmail,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              color: colorScheme.onSurface,
+                            ),
+                          ),
+                        ),
+                        if (displayTime.isNotEmpty)
+                          Text(
+                            displayTime,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: colorScheme.onSurface.withOpacity(0.6),
+                            ),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      conversation.role,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: colorScheme.primary,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      displayMessage,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onSurface.withOpacity(0.7),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (conversation.unreadCount > 0) ...[
+                const SizedBox(width: 12),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: colorScheme.primary,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text(
+                    conversation.unreadCount > 9
+                        ? '9+'
+                        : conversation.unreadCount.toString(),
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: colorScheme.onPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class ChatEmptyState extends StatelessWidget {
+  const ChatEmptyState({
+    super.key,
+    required this.colorScheme,
+    required this.theme,
+  });
+
+  final ColorScheme colorScheme;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircleAvatar(
+              radius: 48,
+              backgroundColor: colorScheme.primary.withOpacity(0.1),
+              child: Icon(
+                Icons.chat_bubble_outline,
+                size: 48,
+                color: colorScheme.primary,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Aún no tienes chats',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleLarge?.copyWith(
+                color: colorScheme.onBackground,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Cuando tengas un terapeuta asignado o envíes un primer mensaje, las conversaciones aparecerán aquí.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onBackground.withOpacity(0.7),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/features/chat/screens/new_chat_screen.dart
+++ b/lib/presentation/features/chat/screens/new_chat_screen.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:xpressatec/core/config/routes.dart';
+import 'package:xpressatec/presentation/features/chat/controllers/chat_controller.dart';
+
+class NewChatScreen extends StatefulWidget {
+  const NewChatScreen({super.key});
+
+  @override
+  State<NewChatScreen> createState() => _NewChatScreenState();
+}
+
+class _NewChatScreenState extends State<NewChatScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _nameController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<ChatController>();
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      backgroundColor: colorScheme.background,
+      appBar: AppBar(
+        backgroundColor: colorScheme.surface,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: colorScheme.onSurface),
+          onPressed: () => Get.back(),
+        ),
+        title: Text(
+          'Nuevo chat',
+          style: theme.textTheme.titleLarge?.copyWith(
+            color: colorScheme.onSurface,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Correo del terapeuta',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: colorScheme.onBackground,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _emailController,
+                keyboardType: TextInputType.emailAddress,
+                decoration: InputDecoration(
+                  hintText: 'ejemplo@correo.com',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+              Text(
+                'Nombre (opcional)',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: colorScheme.onBackground,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _nameController,
+                textCapitalization: TextCapitalization.words,
+                decoration: InputDecoration(
+                  hintText: 'Nombre del terapeuta',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                ),
+              ),
+              const Spacer(),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  icon: const Icon(Icons.chat),
+                  label: const Text('Iniciar chat'),
+                  onPressed: () {
+                    final email = _emailController.text.trim();
+                    final name = _nameController.text.trim();
+                    final success = controller.setRecipientEmail(
+                      email,
+                      displayName: name.isEmpty ? null : name,
+                    );
+                    if (!success) {
+                      return;
+                    }
+
+                    final conversation = controller.getConversationByEmail(email);
+                    if (conversation != null) {
+                      controller.openConversation(conversation);
+                      Get.offNamed(
+                        Routes.chatDetail,
+                        arguments: conversation,
+                      );
+                    } else {
+                      Get.back();
+                    }
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/features/home/screens/home_screen.dart
+++ b/lib/presentation/features/home/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:xpressatec/presentation/features/chat/screens/chat_screen.dart';
+import 'package:xpressatec/core/config/routes.dart';
+import 'package:xpressatec/presentation/features/chat/screens/chat_list_screen.dart';
 import 'package:xpressatec/presentation/features/home/controllers/navigation_controller.dart';
 import 'package:xpressatec/presentation/features/home/widgets/bottom_nav_bar.dart';
 import 'package:xpressatec/presentation/features/home/widgets/custom_drawer.dart';
@@ -20,39 +21,67 @@ class HomeScreen extends StatelessWidget {
 
     return Obx(() {
       final section = navController.currentSection;
+      final theme = Theme.of(context);
+      final colorScheme = theme.colorScheme;
+
       Widget body;
+      PreferredSizeWidget? appBar;
+      Widget? floatingActionButton;
+      FloatingActionButtonLocation? floatingActionButtonLocation;
 
       switch (section) {
         case NavigationSection.teacch:
           body = const TeacchBoardScreen();
+          appBar = XpressatecHeaderAppBar(
+            showMenu: true,
+            onMenuTap: () => _scaffoldKey.currentState?.openDrawer(),
+          );
+          floatingActionButton = const TeacchGeneratePhraseFab();
+          floatingActionButtonLocation = FloatingActionButtonLocation.centerFloat;
           break;
         case NavigationSection.chat:
-          body = const ChatScreen();
+          body = const ChatListScreen();
+          appBar = AppBar(
+            backgroundColor: colorScheme.surface,
+            elevation: 0,
+            leading: IconButton(
+              icon: Icon(Icons.menu, color: colorScheme.onSurface),
+              onPressed: () => _scaffoldKey.currentState?.openDrawer(),
+            ),
+            title: Text(
+              'Chats',
+              style: theme.textTheme.titleLarge?.copyWith(
+                color: colorScheme.onSurface,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          );
+          floatingActionButton = FloatingActionButton(
+            heroTag: 'chatFab',
+            backgroundColor: colorScheme.primary,
+            onPressed: () => Get.toNamed(Routes.newChat),
+            child: Icon(Icons.chat, color: colorScheme.onPrimary),
+          );
+          floatingActionButtonLocation = FloatingActionButtonLocation.endFloat;
           break;
         case NavigationSection.statistics:
           body = const StatisticsScreen();
+          appBar = XpressatecHeaderAppBar(
+            showMenu: true,
+            onMenuTap: () => _scaffoldKey.currentState?.openDrawer(),
+          );
           break;
       }
 
       return Scaffold(
         key: _scaffoldKey,
-        backgroundColor: Colors.white,
-        appBar: section == NavigationSection.chat
-            ? null
-            : XpressatecHeaderAppBar(
-                showMenu: true,
-                onMenuTap: () => _scaffoldKey.currentState?.openDrawer(),
-              ),
+        backgroundColor: colorScheme.background,
+        appBar: appBar,
         drawer: const CustomDrawer(),
         body: body,
         bottomNavigationBar: const BottomNavBar(),
-        floatingActionButton: section == NavigationSection.teacch
-            ? const TeacchGeneratePhraseFab()
-            : null,
-        floatingActionButtonLocation:
-            section == NavigationSection.teacch
-                ? FloatingActionButtonLocation.centerFloat
-                : null,
+        floatingActionButton: floatingActionButton,
+        floatingActionButtonLocation: floatingActionButtonLocation,
       );
     });
   }


### PR DESCRIPTION
## Summary
- add chat conversation tracking to the chat controller for listing and unread counts
- build a WhatsApp-style chat list UI with empty state and entry point for starting new chats
- update navigation and routes so the chat tab opens the list and reuses the existing detail screen

## Testing
- not run (Flutter SDK not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176c3c0360832f9309fb562f29a616)